### PR TITLE
Change: Optional else statement

### DIFF
--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -46,7 +46,7 @@ pub enum Statement {
     VarDeclaration(Box<Name>),
     ValDeclaration(Box<Name>),
     Assignment(Box<Name>, Box<Expression>),
-    IfThenElse(Box<Expression>, Box<Statement>, Box<Statement>),
+    IfThenElse(Box<Expression>, Box<Statement>, Option<Box<Statement>>),
     While(Box<Expression>, Box<Statement>),
     Sequence(Box<Statement>, Box<Statement>),
 }


### PR DESCRIPTION
Changed so that the IfThenElse statement has an optional else statement, by setting it to none. 
Fixed one of the interpreter's tests (eval_complex_sequence).
Created test with nested IfThenElse statements, one with the else statement and, the other, without.