### PR TITLE
Add of Algebric Data Types (ADT) and Pattern matching for ADT

### DIFF
--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -39,9 +39,22 @@ pub fn eval(exp: Expression, env: &Environment<EnvValue>) -> Result<EnvValue, Er
         Expression::IsError(e) => eval_iserror_expression(*e, env),
         Expression::IsNothing(e) => eval_isnothing_expression(*e, env),
         Expression::FuncCall(name, args) => call(name, args, env),
+        Expression::ADTConstructor(adt_name,constructor_name,args ) => adtconstructor_eval(adt_name,constructor_name, args, env),
         _ if is_constant(exp.clone()) => Ok(EnvValue::Exp(exp)),
         _ => Err((String::from("Not implemented yet."), None)),
     }
+}
+
+
+fn _execute_with_env_(stmt: Statement, env: &mut Environment<EnvValue>) -> Result<ControlFlow, ErrorMessage> {
+    let result = execute(stmt, &env.clone())?;
+
+    // Borrow `new_env` instead of moving it
+    if let ControlFlow::Continue(ref new_env) = result {
+        *env = new_env.clone(); // Clone the borrowed environment to update the original
+    }
+
+    Ok(result)
 }
 
 pub fn run(stmt: Statement, env: &Environment<EnvValue>) -> Result<ControlFlow, String> {
@@ -200,7 +213,31 @@ fn execute(stmt: Statement, env: &Environment<EnvValue>) -> Result<ControlFlow, 
             let exp_value = eval(*exp, &new_env)?;
             Ok(ControlFlow::Return(exp_value))
         }
+        
+        Statement::ADTDeclaration(name, constructors) => {
+            // Insert the ADT into the new environment
+            new_env.insert_type(name, constructors);
+            // Return the new environment along with ControlFlow
+            Ok(ControlFlow::Continue(new_env))
+        }
+
+        Statement::Match(exp, cases) => {
+            let value = eval(*exp, &new_env)?;
+        
+            for (pattern, stmt) in cases {
+                if matches_pattern(&value, &pattern, &new_env)? {
+                    return match *stmt {
+                        Statement::Block(stmts) => execute_block(stmts, &new_env),
+                        _ => execute(*stmt, &new_env),
+                    };
+                }
+            }
+            
+            Err(("No matching pattern found".to_string(), None))
+        }
+        
         _ => Err((String::from("not implemented yet"), None)),
+        
     };
 
     match result {
@@ -213,7 +250,102 @@ fn execute(stmt: Statement, env: &Environment<EnvValue>) -> Result<ControlFlow, 
             }
         }
     }
+
+    
 }
+
+
+fn adtconstructor_eval(
+    adt_name: Name,
+    constructor_name: Name,
+    args: Vec<Box<Expression>>,
+    env: &Environment<EnvValue>,
+) -> Result<EnvValue, (String, Option<Expression>)> {
+    if let Some(constructors) = env.get_type(&adt_name) {
+        let value_constructor = constructors.iter().find(|vc| vc.name == constructor_name);
+        
+        if let Some(vc) = value_constructor {
+            if vc.types.len() != args.len() {
+                return Err((
+                    format!(
+                        "Error: Constructor {} expects {} arguments, but received {}",
+                        constructor_name,
+                        vc.types.len(),
+                        args.len()
+                    ),
+                    None,
+                ));
+            }
+
+            let evaluated_args: Result<Vec<Box<Expression>>, (String, Option<Expression>)> = args
+                .into_iter()
+                .map(|arg| {
+                    eval(*arg, env).and_then(|res| match res {
+                        EnvValue::Exp(e) => Ok(Box::new(e)),
+                        _ => Err((
+                            String::from("Error: Expected expression in ADT constructor arguments"),
+                            None,
+                        )),
+                    })
+                })
+                .collect();
+
+            evaluated_args.map(|evaluated| {
+                EnvValue::Exp(Expression::ADTConstructor(adt_name, constructor_name, evaluated))
+            })
+        } else {
+            Err((
+                format!(
+                    "Error: Constructor {} not found in ADT {}",
+                    constructor_name, adt_name
+                ),
+                None,
+            ))
+        }
+    } else {
+        Err((format!("Error: ADT {} not found", adt_name), None))
+    }
+}
+
+
+
+fn matches_pattern(
+    value: &EnvValue,
+    pattern: &Expression,
+    env: &Environment<EnvValue>,
+) -> Result<bool, ErrorMessage> {
+    match (value, pattern) {
+        // Caso o padrão seja um construtor de ADT
+        (
+            EnvValue::Exp(Expression::ADTConstructor(adt_name1, constructor_name1, args1)),
+            Expression::ADTConstructor(adt_name2, constructor_name2, args2),
+        ) => {
+            // Verifica se o nome do ADT e o construtor correspondem
+            if adt_name1 == adt_name2 && constructor_name1 == constructor_name2 {
+                // Verifica se os argumentos correspondem
+                for (arg1, arg2) in args1.iter().zip(args2.iter()) {
+                    let arg_value = eval(*arg1.clone(), env)?;
+                    if !matches_pattern(&arg_value, arg2, env)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+
+        // Caso o padrão seja uma constante (como um número ou booleano)
+        (EnvValue::Exp(exp1), exp2) if is_constant(exp2.clone()) => Ok(exp1 == exp2),
+
+        // Outros casos podem ser adicionados aqui (como variáveis, etc.)
+        _ => Err(("Pattern not supported".to_string(), None)),
+
+    }
+}
+
+
+
 
 //helper function for executing blocks
 fn execute_block(
@@ -829,8 +961,8 @@ mod tests {
     use crate::ir::ast::Function;
     use crate::ir::ast::Statement::*;
     use std::collections::HashMap;
-    //use crate::ir::ast::Type;
     use crate::ir::ast::Type::*;
+    use crate::ir::ast::{Environment,Expression, Statement,Type, ValueConstructor};
     use approx::relative_eq;
 
     #[test]
@@ -2159,4 +2291,531 @@ mod tests {
             Err(s) => assert!(false, "{}", s),
         }
     }
+    #[test]
+    fn test_adt_declaration() {
+        // Declare the environment
+        let env: Environment<EnvValue> = Environment::new();
+    
+        // Declare the Maybe ADT
+        let maybe_adt = Statement::ADTDeclaration(
+            "Maybe".to_string(),
+            vec![
+                ValueConstructor {
+                    name: "Just".to_string(),
+                    types: vec![Type::TInteger],
+                },
+                ValueConstructor {
+                    name: "Nothing".to_string(),
+                    types: vec![],
+                },
+            ],
+        );
+    
+        // Execute the ADT declaration and get the new environment
+        let result = execute(maybe_adt, &env);
+        assert!(result.is_ok());
+    
+        // Extract the new environment from ControlFlow::Continue
+        if let Ok(ControlFlow::Continue(new_env)) = result {
+            // Check if the ADT is correctly inserted into the new environment
+            let maybe_type = new_env.get_type(&"Maybe".to_string());
+            assert!(maybe_type.is_some());
+    
+            // Verify the constructors
+            let constructors = maybe_type.unwrap();
+            println!("Constructors: {:?}", constructors);
+            assert_eq!(constructors.len(), 2);
+            assert_eq!(constructors[0].name, "Just");
+            assert_eq!(constructors[1].name, "Nothing");
+
+        } else {
+            panic!("Expected ControlFlow::Continue");
+        }
+    }
+
+    #[test]
+    fn test_adt_constructor() {
+        let mut env = Environment::new();
+        env.insert_type("Shape".to_string(), vec![
+            ValueConstructor { name: "Circle".to_string(), types: vec![TReal] },
+            ValueConstructor { name: "Rectangle".to_string(), types: vec![TReal, TReal] },
+            ValueConstructor { name: "Triangle".to_string(), types: vec![TReal, TReal, TReal] },
+        ]);
+
+        let circle_expr = Expression::ADTConstructor("Shape".to_string(), "Circle".to_string(), vec![Box::new(Expression::CReal(5.0))]);
+        let result = eval(circle_expr, &env);
+
+        assert!(result.is_ok());
+        if let Ok(EnvValue::Exp(Expression::ADTConstructor(_, _, args))) = result {
+            assert_eq!(args.len(), 1);
+        } else {
+            panic!("Failed to evaluate ADT constructor");
+        }
+    
+    }
+    #[test]
+    fn test_complex_adt() {
+        // Declare the environment
+        let env: Environment<EnvValue> = Environment::new();
+    
+        // Declare the Shape ADT
+        let shape_adt = Statement::ADTDeclaration(
+            "Shape".to_string(),
+            vec![
+                ValueConstructor {
+                    name: "Circle".to_string(),
+                    types: vec![Type::TReal], // One parameter: radius
+                },
+                ValueConstructor {
+                    name: "Rectangle".to_string(),
+                    types: vec![Type::TReal, Type::TReal], // Two parameters: width and height
+                }
+            ],
+        );
+    
+        // Execute the ADT declaration and get the new environment
+        let result = execute(shape_adt, &env);
+        assert!(result.is_ok());
+    
+        // Extract the new environment from ControlFlow::Continue
+        let new_env = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue");
+        };
+    
+        // Check if the ADT is correctly inserted into the new environment
+        let shape_type = new_env.get_type(&"Shape".to_string());
+        assert!(shape_type.is_some());
+    
+        // Print the entire ADT for debugging
+        let constructors = shape_type.unwrap();
+        println!("ADT: Shape");
+        for constructor in constructors {
+            println!(
+                "  - Constructor: {}, Types: {:?}",
+                constructor.name, constructor.types
+            );
+        }
+    
+        // Verify the constructors
+        assert_eq!(constructors.len(), 2);
+    
+        // Verify Circle constructor
+        assert_eq!(constructors[0].name, "Circle");
+        assert_eq!(constructors[0].types, vec![Type::TReal]);
+    
+        // Verify Rectangle constructor
+        assert_eq!(constructors[1].name, "Rectangle");
+        assert_eq!(constructors[1].types, vec![Type::TReal, Type::TReal]);
+    
+        // Create instances of the ADT
+        let circle_instance = Expression::ADTConstructor(
+            "Shape".to_string(), // ADT name
+            "Circle".to_string(), // Constructor name
+            vec![Box::new(Expression::CReal(5.0))], // Arguments (radius)
+        );
+    
+        let rectangle_instance = Expression::ADTConstructor(
+            "Shape".to_string(), // ADT name
+            "Rectangle".to_string(), // Constructor name
+            vec![
+                Box::new(Expression::CReal(3.0)), // Argument (width)
+                Box::new(Expression::CReal(4.0)), // Argument (height)
+            ],
+        );
+    
+        // Assign instances to variables
+        let assign_rectangle = Statement::Assignment(
+            "rectangle".to_string(), // Variable name
+            Box::new(rectangle_instance), // Value
+            Some(Type::Tadt("Shape".to_string(), constructors.clone())), // Type annotation
+        );
+    
+        let assign_circle = Statement::Assignment(
+            "circle".to_string(), // Variable name
+            Box::new(circle_instance), // Value
+            Some(Type::Tadt("Shape".to_string(), constructors.clone())), // Type annotation
+        );
+    
+        // Execute the assignments
+        let result = execute(assign_rectangle, &new_env);
+        assert!(result.is_ok());
+    
+        // Extract the updated environment after the first assignment
+        let new_env_after_rectangle = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue after rectangle assignment");
+        };
+    
+        // Verify the rectangle value is present
+        let rectangle_value = new_env_after_rectangle.search_frame("rectangle".to_string());
+        println!("Rectangle value: {:?}", rectangle_value);
+        assert!(rectangle_value.is_some());
+    
+        let result = execute(assign_circle, &new_env_after_rectangle);
+        assert!(result.is_ok());
+    
+        // Extract the final environment after the second assignment
+        let final_env = if let Ok(ControlFlow::Continue(final_env)) = result {
+            final_env
+        } else {
+            panic!("Expected ControlFlow::Continue after circle assignment");
+        };
+    
+        // Verify that the variables are correctly assigned
+        let circle_value = final_env.search_frame("circle".to_string());
+        println!("Circle value: {:?}", circle_value);
+        assert!(circle_value.is_some());
+    
+        let rectangle_value = final_env.search_frame("rectangle".to_string());
+        println!("Rectangle value: {:?}", rectangle_value);
+        assert!(rectangle_value.is_some());
+    }
+
+
+    #[test]
+    fn test_adt_with_dinamic_env() {
+        // Declare the environment as mutable
+        let mut env: Environment<EnvValue> = Environment::new();
+    
+        // Declare the Shape ADT
+        let shape_adt = Statement::ADTDeclaration(
+            "Shape".to_string(),
+            vec![
+                ValueConstructor {
+                    name: "Circle".to_string(),
+                    types: vec![Type::TReal], // One parameter: radius
+                },
+                ValueConstructor {
+                    name: "Rectangle".to_string(),
+                    types: vec![Type::TReal, Type::TReal], // Two parameters: width and height
+                },
+            ],
+        );
+    
+        // Execute the ADT declaration and update the environment
+        let result = _execute_with_env_(shape_adt, &mut env);
+        assert!(result.is_ok());
+    
+        // Check if the ADT is correctly inserted into the environment
+        let shape_type = env.get_type(&"Shape".to_string());
+        assert!(shape_type.is_some(), "ADT 'Shape' was not inserted into the environment");
+    
+        // Print the entire ADT for debugging
+        let constructors = shape_type.unwrap();
+        println!("ADT: Shape");
+        for constructor in constructors {
+            println!(
+                "  - Constructor: {}, Types: {:?}",
+                constructor.name, constructor.types
+            );
+        }
+    
+        // Verify the constructors
+        assert_eq!(constructors.len(), 2);
+    
+        // Verify Circle constructor
+        assert_eq!(constructors[0].name, "Circle");
+        assert_eq!(constructors[0].types, vec![Type::TReal]);
+    
+        // Verify Rectangle constructor
+        assert_eq!(constructors[1].name, "Rectangle");
+        assert_eq!(constructors[1].types, vec![Type::TReal, Type::TReal]);
+    
+        // Create instances of the ADT
+        let circle_instance = Expression::ADTConstructor(
+            "Shape".to_string(), // ADT name
+            "Circle".to_string(), // Constructor name
+            vec![Box::new(Expression::CReal(5.0))], // Arguments (radius)
+        );
+    
+        let rectangle_instance = Expression::ADTConstructor(
+            "Shape".to_string(), // ADT name
+            "Rectangle".to_string(), // Constructor name
+            vec![
+                Box::new(Expression::CReal(3.0)), // Argument (width)
+                Box::new(Expression::CReal(4.0)), // Argument (height)
+            ],
+        );
+    
+        // Assign instances to variables
+        let assign_rectangle = Statement::Assignment(
+            "rectangle".to_string(), // Variable name
+            Box::new(rectangle_instance), // Value
+            Some(Type::Tadt("Shape".to_string(), constructors.clone())), // Type annotation
+        );
+    
+        let assign_circle = Statement::Assignment(
+            "circle".to_string(), // Variable name
+            Box::new(circle_instance), // Value
+            Some(Type::Tadt("Shape".to_string(), constructors.clone())), // Type annotation
+        );
+    
+        // Execute the assignments and update the environment in place
+        let result = _execute_with_env_(assign_rectangle, &mut env);
+        assert!(result.is_ok());
+    
+        // Verify the rectangle value is present
+        let rectangle_value = env.search_frame("rectangle".to_string());
+        println!("Rectangle value: {:?}", rectangle_value);
+        assert!(rectangle_value.is_some());
+    
+        // Execute the circle assignment and update the environment in place
+        let result = _execute_with_env_(assign_circle, &mut env);
+        assert!(result.is_ok());
+    
+        // Verify that the variables are correctly assigned
+        let circle_value = env.search_frame("circle".to_string());
+        println!("Circle value: {:?}", circle_value);
+        assert!(circle_value.is_some());
+    
+        let rectangle_value = env.search_frame("rectangle".to_string());
+        println!("Rectangle value: {:?}", rectangle_value);
+        assert!(rectangle_value.is_some());
+    }
+
+
+
+    #[test]
+    fn test_adt_pattern_matching() {
+        // Cria um novo ambiente
+        let env: Environment<EnvValue> = Environment::new();
+        println!("Ambiente inicial criado.");
+
+        // Declara a ADT Shape com dois construtores: Circle e Rectangle
+        let shape_adt = Statement::ADTDeclaration(
+            "Shape".to_string(),
+            vec![
+                ValueConstructor {
+                    name: "Circle".to_string(),
+                    types: vec![Type::TReal], // Circle tem um parâmetro: radius
+                },
+                ValueConstructor {
+                    name: "Rectangle".to_string(),
+                    types: vec![Type::TReal, Type::TReal], // Rectangle tem dois parâmetros: width e height
+                },
+            ],
+        );
+
+        println!("Declarando a ADT Shape com construtores Circle e Rectangle...");
+
+        // Executa a declaração da ADT e obtém o novo ambiente
+        let result = execute(shape_adt, &env);
+        assert!(result.is_ok());
+        println!("ADT Shape declarada com sucesso.");
+
+        let new_env = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue");
+        };
+
+        // Cria uma instância de Circle com radius = 5.0
+        let circle_instance = Expression::ADTConstructor(
+            "Shape".to_string(), // Nome da ADT
+            "Circle".to_string(), // Nome do construtor
+            vec![Box::new(Expression::CReal(5.0))], // Argumento (radius)
+        );
+
+        println!("Criando uma instância de Circle com radius = 5.0...");
+
+        // Atribui a instância de Circle a uma variável chamada "shape"
+        let assign_circle = Statement::Assignment(
+            "shape".to_string(), // Nome da variável
+            Box::new(circle_instance), // Valor (instância de Circle)
+            Some(Type::Tadt("Shape".to_string(), new_env.get_type(&"Shape".to_string()).unwrap().clone())), // Tipo (Shape)
+        );
+
+        println!("Atribuindo a instância de Circle à variável 'shape'...");
+
+        // Executa a atribuição e obtém o novo ambiente
+        let result = execute(assign_circle, &new_env);
+        assert!(result.is_ok());
+        println!("Instância de Circle atribuída à variável 'shape' com sucesso.");
+
+        let new_env_after_assignment = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue");
+        };
+
+        // Define um bloco de pattern matching para verificar o tipo da variável "shape"
+        let match_stmt = Statement::Match(
+            Box::new(Expression::Var("shape".to_string())), // Expressão a ser comparada
+            vec![
+                // Caso 1: Circle
+                (
+                    Expression::ADTConstructor("Shape".to_string(), "Circle".to_string(), vec![]),
+                    Box::new(Statement::Return(Box::new(Expression::CString("It's a circle!".to_string())))),
+                ),
+                // Caso 2: Rectangle
+                (
+                    Expression::ADTConstructor("Shape".to_string(), "Rectangle".to_string(), vec![]),
+                    Box::new(Statement::Return(Box::new(Expression::CString("It's a rectangle!".to_string())))),
+                ),
+            ],
+        );
+
+        println!("Executando pattern matching na variável 'shape'...");
+
+        // Executa o pattern matching
+        let result = execute(match_stmt, &new_env_after_assignment);
+        assert!(result.is_ok());
+        println!("Pattern matching executado com sucesso.");
+
+        // Verifica o resultado do pattern matching
+        if let Ok(ControlFlow::Return(EnvValue::Exp(Expression::CString(message)))) = result {
+            println!("Resultado do pattern matching: {}", message);
+            assert_eq!(message, "It's a circle!"); // Espera-se que o padrão Circle seja correspondido
+        } else {
+            panic!("Expected ControlFlow::Return with a string message");
+        }
+    }
+
+    #[test]
+    fn test_pattern_matching_calculando_area_figuras() {
+        // Cria um novo ambiente
+        let env: Environment<EnvValue> = Environment::new();
+
+        // Declara a ADT FiguraGeometrica com três construtores: Circle, Rectangle e Triangle
+        let figura_adt = Statement::ADTDeclaration(
+            "FiguraGeometrica".to_string(),
+            vec![
+                ValueConstructor {
+                    name: "Círculo".to_string(),
+                    types: vec![Type::TReal], // Um parâmetro: raio
+                },
+                ValueConstructor {
+                    name: "Retângulo".to_string(),
+                    types: vec![Type::TReal, Type::TReal], // Dois parâmetros: largura e altura
+                },
+                ValueConstructor {
+                    name: "Triângulo".to_string(),
+                    types: vec![Type::TReal, Type::TReal], // Dois parâmetros: base e altura
+                },
+            ],
+        );
+
+        // Executa a declaração da ADT e obtém o novo ambiente
+        let result = execute(figura_adt, &env);
+        assert!(result.is_ok());
+
+        let new_env = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue");
+        };
+
+        // Cria instâncias de figuras geométricas com valores para os parâmetros
+        let circulo_instance = Expression::ADTConstructor(
+            "FiguraGeometrica".to_string(),
+            "Círculo".to_string(),
+            vec![Box::new(Expression::CReal(5.0))], // Raio = 5.0
+        );
+
+        let retangulo_instance = Expression::ADTConstructor(
+            "FiguraGeometrica".to_string(),
+            "Retângulo".to_string(),
+            vec![
+                Box::new(Expression::CReal(3.0)), // Largura = 3.0
+                Box::new(Expression::CReal(4.0)), // Altura = 4.0
+            ],
+        );
+
+        let triangulo_instance = Expression::ADTConstructor(
+            "FiguraGeometrica".to_string(),
+            "Triângulo".to_string(),
+            vec![
+                Box::new(Expression::CReal(6.0)), // Base = 6.0
+                Box::new(Expression::CReal(4.0)), // Altura = 4.0
+            ],
+        );
+
+        // Atribui as instâncias a variáveis
+        let assign_circulo = Statement::Assignment(
+            "X".to_string(),
+            Box::new(circulo_instance),
+            Some(Type::Tadt(
+                "FiguraGeometrica".to_string(),
+                new_env.get_type(&"FiguraGeometrica".to_string()).unwrap().clone(),
+            )),
+        );
+
+        let assign_retangulo = Statement::Assignment(
+            "Y".to_string(),
+            Box::new(retangulo_instance),
+            Some(Type::Tadt(
+                "FiguraGeometrica".to_string(),
+                new_env.get_type(&"FiguraGeometrica".to_string()).unwrap().clone(),
+            )),
+        );
+
+        let assign_triangulo = Statement::Assignment(
+            "Z".to_string(),
+            Box::new(triangulo_instance),
+            Some(Type::Tadt(
+                "FiguraGeometrica".to_string(),
+                new_env.get_type(&"FiguraGeometrica".to_string()).unwrap().clone(),
+            )),
+        );
+
+        // Executa as atribuições
+        let result = execute(assign_circulo, &new_env);
+        assert!(result.is_ok());
+
+        let new_env_after_circulo = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue after circulo assignment");
+        };
+
+        let result = execute(assign_retangulo, &new_env_after_circulo);
+        assert!(result.is_ok());
+
+        let new_env_after_retangulo = if let Ok(ControlFlow::Continue(new_env)) = result {
+            new_env
+        } else {
+            panic!("Expected ControlFlow::Continue after retangulo assignment");
+        };
+
+        let result = execute(assign_triangulo, &new_env_after_retangulo);
+        assert!(result.is_ok());
+
+        
+        let match_stmt = Statement::Match(
+            Box::new(Expression::Var("X".to_string())), // Expressão a ser comparada
+            vec![
+                // Caso 1: Círculo -> Área = π * r^2
+                (
+                    Expression::ADTConstructor("FiguraGeometrica".to_string(), "Círculo".to_string(), vec![]),
+                    Box::new(Statement::Return(Box::new(Expression::CReal(3.14 * 5.0 * 5.0)))), // Área do círculo
+                ),
+                // Caso 2: Retângulo -> Área = largura * altura
+                (
+                    Expression::ADTConstructor("FiguraGeometrica".to_string(), "Retângulo".to_string(), vec![]),
+                    Box::new(Statement::Return(Box::new(Expression::CReal(3.0 * 7.0)))), // Área do retângulo
+                ),
+                // Caso 3: Triângulo -> Área = (base * altura) / 2
+                (
+                    Expression::ADTConstructor("FiguraGeometrica".to_string(), "Triângulo".to_string(), vec![]),
+                    Box::new(Statement::Return(Box::new(Expression::CReal(0.5 * 6.0 * 4.0)))), // Área do triângulo
+                ),
+            ],
+        );
+
+        // Executa o pattern matching
+        let result = execute(match_stmt, &new_env_after_retangulo);
+        assert!(result.is_ok());
+
+        // Verifica o resultado do pattern matching
+        if let Ok(ControlFlow::Return(EnvValue::Exp(Expression::CReal(area)))) = result {
+            println!("Resultado da área calculada: {}", area);
+            assert_eq!(area, 78.5); 
+        } else {
+            panic!("Expected ControlFlow::Return with a real value for area");
+        }
+    }
+
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,7 +1,7 @@
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_while, take_while1},
-    character::complete::{char, digit1, line_ending, space0, space1},
+    character::complete::{char, digit1, line_ending, space0, space1, multispace0},
     combinator::{map, map_res, opt, recognize},
     error::Error,
     multi::{many0, many1, separated_list0, separated_list1},
@@ -36,7 +36,7 @@ const KEYWORDS: &[&str] = &[
 
 use crate::ir::ast::Function;
 use crate::ir::ast::Type;
-use crate::ir::ast::{Expression, Name, Statement};
+use crate::ir::ast::{Expression, Name, Statement, ValueConstructor};
 
 fn identifier(input: &str) -> IResult<&str, Name> {
     let (input, id) = take_while1(|c: char| c.is_alphanumeric() || c == '_')(input)?;
@@ -104,6 +104,8 @@ fn statement(input: &str) -> IResult<&str, Statement> {
         return_statement,
         assignment,
         declaration,
+        adt_declaration, // Add ADT declaration
+        match_expression, // Add pattern matching
     ))(input)
 }
 
@@ -537,6 +539,99 @@ pub fn parse(input: &str) -> IResult<&str, Vec<Statement>> {
     let (input, _) = space0(input)?; // Consume trailing whitespace
     Ok((input, statements))
 }
+
+
+fn adt_declaration(input: &str) -> IResult<&str, Statement> {
+    let (input, _) = tag("adt")(input)?;
+    let (input, _) = space1(input)?;
+    let (input, name) = identifier(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = char('=')(input)?;
+    let (input, _) = space0(input)?;
+    let (input, constructors) = separated_list1(
+        preceded(space0, char('|')), // Match `|`, allowing leading spaces
+        preceded(space0, value_constructor), // Consume extra spaces before each constructor
+    )(input)?;
+    
+
+    Ok((input, Statement::ADTDeclaration(name, constructors)))
+}
+
+fn value_constructor(input: &str) -> IResult<&str, ValueConstructor> {
+    let (input, name) = identifier(input)?;
+    let (input, types) = many0(preceded(space1, type_annotation))(input)?;
+
+    Ok((input, ValueConstructor { name, types }))
+}
+
+fn type_annotation(input: &str) -> IResult<&str, Type> {
+    alt((
+        map(tag("Int"), |_| Type::TInteger),
+        map(tag("Bool"), |_| Type::TBool),
+        map(tag("Real"), |_| Type::TReal),
+        map(tag("String"), |_| Type::TString),
+        map(tag("Any"), |_| Type::TAny),
+    ))(input)
+}
+
+fn match_expression(input: &str) -> IResult<&str, Statement> {
+    let (input, _) = multispace0(input)?; // Skip leading spaces & newlines
+    let (input, _) = tag("match")(input)?; // Parse the "match" keyword
+    let (input, _) = space1(input)?; // Require at least one space after "match"
+    let (input, exp) = expression(input)?; // Parse the expression to match 
+    let (input, _) = multispace0(input)?; // Skip spaces & newlines
+    let (input, _) = char('{')(input)?; // Parse the opening brace
+    let (input, _) = multispace0(input)?; // Skip spaces & newlines
+
+    // Parse the match cases
+    let (input, cases) = separated_list0(
+        tuple((multispace0, char(','), multispace0)), // Allow spaces/newlines before and after `,`
+        match_case, // Parse each match case
+    )(input)?;
+
+    let (input, _) = multispace0(input)?; // Skip spaces & newlines
+    let (input, _) = char('}')(input)?; // Parse the closing brace
+
+    Ok((input, Statement::Match(Box::new(exp), cases)))
+}
+
+fn match_case(input: &str) -> IResult<&str, (Expression, Box<Statement>)> {
+    //println!("Parsing match case: {}", input); // Debug print
+    let (input, _) = multispace0(input)?; // Skip spaces & newlines
+    //println!("After skipping spaces: {}", input); // Debug print
+    let (input, pattern) = pattern(input)?; 
+    //println!("Parsed pattern: {:?}", pattern); // Debug print
+    let (input, _) = space0(input)?; // Skip optional spaces
+    //println!("After skipping spaces before =>: {}", input); // Debug print
+    let (input, _) = tag("=>")(input)?; // Parse the "=>" operator
+    //println!("After parsing =>: {}", input); // Debug print
+    let (input, _) = space0(input)?; // Skip optional spaces
+    //println!("After skipping spaces after =>: {}", input); // Debug print
+    let (input, stmt) = statement(input)?; 
+    //println!("Parsed statement: {:?}", stmt); // Debug print
+
+    Ok((input, (pattern, Box::new(stmt))))
+}
+fn pattern(input: &str) -> IResult<&str, Expression> {
+    alt((
+        adt_pattern, // Handle ADT patterns first (e.g., "Circle r")
+        map(identifier, Expression::Var), // Fallback to variables
+    ))(input)
+}
+
+fn arg_pattern(input: &str) -> IResult<&str, Expression> {
+    map(identifier, Expression::Var)(input) // Only parse variables
+}
+
+fn adt_pattern(input: &str) -> IResult<&str, Expression> {
+    let (input, adt_name) = identifier(input)?; // Parse the ADT name 
+    let (input, _) = space0(input)?; // Skip optional spaces
+    let (input, constructor_name) = identifier(input)?; // Parse the constructor name 
+    let (input, args) = many1(preceded(space1, arg_pattern))(input)?; // Parse the arguments 
+
+    Ok((input, Expression::ADTConstructor(adt_name, constructor_name, args.into_iter().map(Box::new).collect())))
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -1340,20 +1435,198 @@ mod tests {
 
         assert!(result.is_err());
     }
-
+    
     #[test]
     fn test_var_declaration_with_keyword_while() {
         let input = "while = 10";
         let result = assignment(input);
-
+        
         assert!(result.is_err());
-    }
-
+    }    
+    
     #[test]
     fn test_var_declaration_with_keyword_ok() {
         let input = "Ok = 10";
         let result = assignment(input);
-
+        
         assert!(result.is_err());
+    }    
+    
+    #[test]
+    fn test_adt_pattern() {
+        // Test case 1: Circle with one argument
+        let input = "Shape Circle r";
+        let result = adt_pattern(input);
+        assert!(result.is_ok());
+        let (remaining_input, parsed_expr) = result.unwrap();
+        assert_eq!(remaining_input, ""); // Ensure the entire input is consumed
+        assert_eq!(
+            parsed_expr,
+            Expression::ADTConstructor(
+                "Shape".to_string(), // ADT name
+                "Circle".to_string(), // Constructor name
+                vec![Box::new(Expression::Var("r".to_string()))] // Argument
+            )
+        );
+    
+        println!("Passou");
+    
+        // Test case 2: Rectangle with two arguments
+        let input = "Shape Rectangle w h";
+        let result = adt_pattern(input);
+        assert!(result.is_ok());
+        let (remaining_input, parsed_expr) = result.unwrap();
+        assert_eq!(remaining_input, ""); // Ensure the entire input is consumed
+        assert_eq!(
+            parsed_expr,
+            Expression::ADTConstructor(
+                "Shape".to_string(), // ADT name
+                "Rectangle".to_string(), // Constructor name
+                vec![
+                    Box::new(Expression::Var("w".to_string())), // First argument
+                    Box::new(Expression::Var("h".to_string()))  // Second argument
+                ]
+            )
+        );
+    
+        // Test case 3: Triangle with three arguments
+        let input = "Shape Triangle b h s";
+        let result = adt_pattern(input);
+        assert!(result.is_ok());
+        let (remaining_input, parsed_expr) = result.unwrap();
+        assert_eq!(remaining_input, ""); // Ensure the entire input is consumed
+        assert_eq!(
+            parsed_expr,
+            Expression::ADTConstructor(
+                "Shape".to_string(), // ADT name
+                "Triangle".to_string(), // Constructor name
+                vec![
+                    Box::new(Expression::Var("b".to_string())), // First argument
+                    Box::new(Expression::Var("h".to_string())), // Second argument
+                    Box::new(Expression::Var("s".to_string()))  // Third argument
+                ]
+            )
+        );
+    
+        // Test case 4: Invalid input (missing argument)
+        let input = "Shape Circle";
+        let result = adt_pattern(input);
+        assert!(result.is_err()); // Expect an error because the argument is missing
     }
+    
+
+    #[test]
+    fn parser_test_adt_and_pattern_matching2() {
+        // Define the ADT for geometric shapes
+        let adt_input = "adt FG = Circle Bool | Rectangle Bool Bool | Triangle Bool Bool Bool";
+        println!("Parsing ADT: {}", adt_input);
+        let adt_result = adt_declaration(adt_input);
+        println!("ADT Result: {:?}", adt_result);
+        assert!(adt_result.is_ok());
+    
+        // Define the match expression
+        let match_input ="
+            match shape {
+                FG Circle r => return 3.14 * r * r,
+                FG Rectangle w h => return w * h,
+                FG Triangle b h s => return 0.5 * b * h
+            }
+        ";
+        println!("Parsing Match Expression: {}", match_input);
+        let match_result = match_expression(match_input);
+        println!("Match Result: {:?}", match_result);
+        assert!(match_result.is_ok());
+    
+        // Verify the parsed ADT
+        let (_, adt) = adt_result.unwrap();
+        println!("Parsed ADT: {:?}", adt);
+        assert_eq!(
+            adt,
+            Statement::ADTDeclaration(
+                "FG".to_string(),
+                vec![
+                    ValueConstructor {
+                        name: "Circle".to_string(),
+                        types: vec![Type::TBool],
+                    },
+                    ValueConstructor {
+                        name: "Rectangle".to_string(),
+                        types: vec![Type::TBool, Type::TBool],
+                    },
+                    ValueConstructor {
+                        name: "Triangle".to_string(),
+                        types: vec![Type::TBool, Type::TBool, Type::TBool],
+                    },
+                ]
+            )
+        );
+    
+        // Verify the parsed match expression
+        let (_, match_stmt) = match_result.unwrap();
+        println!("Parsed Match Statement: {:?}", match_stmt);
+        assert_eq!(
+            match_stmt,
+            Statement::Match(
+                Box::new(Expression::Var("shape".to_string())),
+                vec![
+                    (
+                        Expression::ADTConstructor(
+                            "FG".to_string(),
+                            "Circle".to_string(),
+                            vec![Box::new(Expression::Var("r".to_string()))]
+                        ),
+                        Box::new(Statement::Return(Box::new(Expression::Mul(
+                            Box::new(Expression::Mul(
+                                Box::new(Expression::CReal(3.14)),
+                                Box::new(Expression::Var("r".to_string()))
+                            )),
+                            Box::new(Expression::Var("r".to_string()))
+                        )))
+                    ),
+                ),
+                    (
+                        Expression::ADTConstructor(
+                            "FG".to_string(),
+                            "Rectangle".to_string(),
+                            vec![
+                                Box::new(Expression::Var("w".to_string())),
+                                Box::new(Expression::Var("h".to_string()))
+                            ]
+                        ),
+                        Box::new(Statement::Return(Box::new(Expression::Mul(
+                            Box::new(Expression::Var("w".to_string())),
+                            Box::new(Expression::Var("h".to_string()))
+                        )))
+                    ),
+                    ),
+                    (
+                        Expression::ADTConstructor(
+                            "FG".to_string(),
+                            "Triangle".to_string(),
+                            vec![
+                                Box::new(Expression::Var("b".to_string())),
+                                Box::new(Expression::Var("h".to_string())),
+                                Box::new(Expression::Var("s".to_string()))
+                            ]
+                        ),
+                        Box::new(Statement::Return(Box::new(Expression::Mul(
+                            Box::new(Expression::Mul(
+                            Box::new(Expression::CReal(0.5)),
+                            Box::new(Expression::Var("b".to_string())),
+                            )),
+                                Box::new(Expression::Var("h".to_string()))
+                            )
+                    ))
+                    ),
+                ),
+                ]
+            )
+        );
+    }
+
+
 }
+
+
+
+    

--- a/src/tc/type_checker.rs
+++ b/src/tc/type_checker.rs
@@ -38,6 +38,8 @@ pub fn check_exp(exp: Expression, env: &Environment<Type>) -> Result<Type, Error
         Expression::Unwrap(e) => check_unwrap_type(*e, env),
         Expression::Propagate(e) => check_propagate_type(*e, env),
         Expression::FuncCall(name, args) => check_func_call(name, args, env),
+        Expression::ADTConstructor(adt_name,constructor_name,args ) => check_adt_constructor(adt_name,constructor_name, args, env),
+        
         //_ => Err(String::from("not implemented yet")),
     }
 }
@@ -166,9 +168,69 @@ pub fn check_stmt(stmt: Statement, env: &Environment<Type>) -> Result<ControlFlo
                 Err(format!("[Syntax Error] return statement outside function."))
             }
         }
+        Statement::ADTDeclaration(name, constructors) => {
+            new_env.insert_type(name.clone(), constructors.clone());
+            Ok(ControlFlow::Continue(new_env))
+        }
         _ => Err(String::from("not implemented yet.")),
     }
 }
+
+
+fn check_adt_constructor(
+    adt_name: Name,          // Name of the ADT
+    constructor_name: Name,  // Name of the constructor
+    args: Vec<Box<Expression>>,
+    env: &Environment<Type>,
+) -> Result<Type, ErrorMessage> {
+    // Retrieve the ADT definition from the environment
+    if let Some(constructors) = env.get_type(&adt_name) {
+        // Find the correct constructor by name
+        if let Some(constructor) = constructors.iter().find(|c| c.name == constructor_name) {
+            // Check if the number of arguments matches the expected number
+            if args.len() != constructor.types.len() {
+                return Err(format!(
+                    "[Type Error in '{}'] ADT constructor '{}' expected {} arguments, found {}.",
+                    env.scope_name(),
+                    constructor_name,
+                    constructor.types.len(),
+                    args.len()
+                ));
+            }
+
+            // Check if the arguments match the expected constructor types
+            for (arg, expected_type) in args.iter().zip(&constructor.types) {
+                let arg_type = check_exp(*arg.clone(), env)?;
+                if arg_type != *expected_type {
+                    return Err(format!(
+                        "[Type Error in '{}'] ADT constructor '{}' has mismatched argument types: expected '{:?}', found '{:?}'.",
+                        env.scope_name(),
+                        constructor_name,
+                        expected_type,
+                        arg_type
+                    ));
+                }
+            }
+
+            // Return the ADT type
+            Ok(Type::Tadt(adt_name.clone(), constructors.clone()))
+        } else {
+            Err(format!(
+                "[Type Error in '{}'] ADT constructor '{}' not found in ADT '{}'.",
+                env.scope_name(),
+                constructor_name,
+                adt_name
+            ))
+        }
+    } else {
+        Err(format!(
+            "[Type Error in '{}'] ADT '{}' is not defined.",
+            env.scope_name(),
+            adt_name
+        ))
+    }
+}
+
 
 fn check_func_call(
     name: String,


### PR DESCRIPTION
# Implementação de ADT e Pattern Matching (grupo 9)

## Descrição  
Este PR adiciona suporte para **Tipos de Dados Abstratos (ADT)** e **Pattern Matching** bem como o parser de ambos. A implementação inclui:  

- **Definição de ADTs**: Suporte para definição de tipos de dados complexos.
- **Pattern Matching**: Implementação da correspondência de padrões para facilitar a deconstrução de ADTs.  
- **Extensão do Parser**: Modificações no parser para reconhecer e processar ADTs e padrões.  

## Mudanças Principais  
- Adição de Tadt e ADTConstructor, ADTDeclaration e Match em ast.rs.  
- Implementação de `Pattern Match` para processar padrões e extrair dados.  
- Modificação do `Parser` para suportar a nova sintaxe.  
- Testes unitários para validar a criação de ADTs e a aplicação de pattern matching.  

## Exemplos de Uso  

### Interpreter:

```rs
let env: Environment<EnvValue> = Environment::new();

// Declarando o ADT Shape
let shape_adt = Statement::ADTDeclaration(
    "Shape".to_string(),
    vec![
        ValueConstructor {
            name: "Circle".to_string(),
            types: vec![Type::TReal],
        },
        ValueConstructor {
            name: "Rectangle".to_string(),
            types: vec![Type::TReal, Type::TReal],
        }
    ],
);

// Executando a declaração do ADT
let new_env = match execute(shape_adt, &env) {
    Ok(ControlFlow::Continue(new_env)) => new_env,
    _ => panic!("Erro ao declarar ADT"),
};

// Criando instâncias do ADT
let circle_instance = Expression::ADTConstructor(
    "Shape".to_string(),
    "Circle".to_string(),
    vec![Box::new(Expression::CReal(5.0))],
);

let rectangle_instance = Expression::ADTConstructor(
    "Shape".to_string(),
    "Rectangle".to_string(),
    vec![
        Box::new(Expression::CReal(3.0)),
        Box::new(Expression::CReal(4.0)),
    ],
);

// Atribuindo instâncias a variáveis
let assign_circle = Statement::Assignment(
    "circle".to_string(),
    Box::new(circle_instance),
    Some(Type::Tadt("Shape".to_string(), new_env.get_type("Shape").unwrap())),
);

let assign_rectangle = Statement::Assignment(
    "rectangle".to_string(),
    Box::new(rectangle_instance),
    Some(Type::Tadt("Shape".to_string(), new_env.get_type("Shape").unwrap())),
);

// Executando as atribuições
let result = execute(assign_rectangle, &new_env);
let new_env_after_rectangle = match result {
    Ok(ControlFlow::Continue(env)) => env,
    _ => panic!("Erro ao atribuir Rectangle"),
};

let result = execute(assign_circle, &new_env_after_rectangle);
let final_env = match result {
    Ok(ControlFlow::Continue(env)) => env,
    _ => panic!("Erro ao atribuir Circle"),
};
```
Perceba que foi necessario criar outro env entre os executes que fazem o assign de cada instancia. Se isso não for feito as intancias começam a se sobrepor.


Pensando em melhorar esse processo implementei(sem saber se é valido)  a função execute_with_env que absorve parte desse processo:

```rs
 // executando o assign com a função de suporte
        let assign_rectangle = Statement::Assignment(
            "rectangle".to_string(), // Variable name
            Box::new(rectangle_instance), // Value
            Some(Type::Tadt("Shape".to_string(), constructors.clone())), // Type annotation
        );
    
        let assign_circle = Statement::Assignment(
            "circle".to_string(), // Variable name
            Box::new(circle_instance), // Value
            Some(Type::Tadt("Shape".to_string(), constructors.clone())), // Type annotation
        );
    
        // Execute the assignments and update the environment in place
        let result = _execute_with_env_(assign_rectangle, &mut env);
        assert!(result.is_ok());
        // Execute the circle assignment and update the environment in place
        let result = _execute_with_env_(assign_circle, &mut env);
        assert!(result.is_ok());
    
```


Além disso o Match no interpretador segue o seguinte formato:

```rs
let match_stmt = Statement::Match(
            Box::new(Expression::Var("shape".to_string())), // Expressão a ser comparada
            vec![
                // Caso 1: Circle
                (
                    Expression::ADTConstructor("Shape".to_string(), "Circle".to_string(), vec![]),
                    Box::new(Statement::Return(Box::new(Expression::CString("It's a circle!".to_string())))),
                ),
                // Caso 2: Rectangle
                (
                    Expression::ADTConstructor("Shape".to_string(), "Rectangle".to_string(), vec![]),
                    Box::new(Statement::Return(Box::new(Expression::CString("It's a rectangle!".to_string())))),
                ),
            ],
        );

        println!("Executando pattern matching na variável 'shape'...");

        // Executa o pattern matching
        let result = execute(match_stmt, &new_env_after_assignment);
```



### Parser:
```rs
// Input de um ADT
input = "adt FG = Circle Bool | Rectangle Bool Bool | Triangle Bool Bool Bool"
```
onde **adt** é a palavra chave, **FG** é o nome da ADT. e os construtores são separados por **|**

```rs
input de um pattern matching:
"
  match shape {
       FG Circle r => return 3.14 * r * r,
       FG Rectangle w h => return w * h,
       FG Triangle b h s => return 0.5 * b * h
   }
"
```



## Adições futuras
- **Expansão dos tipos possiveis de Match**: principalmente o suporte a varivel
- **Melhorar o gerenciamento do Env e do execute para instancia de ADTs**
