### PR TITLE
Alterações buscando maior eficiência e código mais idiomático

### DIFF
--- a/src/environment/environment.rs
+++ b/src/environment/environment.rs
@@ -1,6 +1,6 @@
 use crate::ir::ast::Function;
 use crate::ir::ast::Name;
-use crate::ir::ast::ValueConstructor;
+use crate::ir::ast::Type;
 use std::collections::HashMap;
 use std::collections::LinkedList;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use std::sync::Arc;
 pub struct Scope<A> {
     pub variables: HashMap<Name, (bool, A)>,
     pub functions: HashMap<Name, Function>,
-    pub adts: HashMap<Name, Arc<Vec<ValueConstructor>>>,
+    pub adts: HashMap<Name, Arc<HashMap<Name, Vec<Type>>>>,
 }
 
 impl<A: Clone> Scope<A> {
@@ -31,7 +31,7 @@ impl<A: Clone> Scope<A> {
         return ();
     }
 
-    fn map_adt(&mut self, name: Name, adt: Vec<ValueConstructor>) -> () {
+    fn map_adt(&mut self, name: Name, adt: HashMap<Name, Vec<Type>>) -> () {
         self.adts.insert(name.clone(), Arc::new(adt));
         return ();
     }
@@ -46,7 +46,7 @@ impl<A: Clone> Scope<A> {
         self.functions.get(name)
     }
 
-    fn lookup_adt(&self, name: &Name) -> Option<&Arc<Vec<ValueConstructor>>> {
+    fn lookup_adt(&self, name: &Name) -> Option<&Arc<HashMap<Name, Vec<Type>>>> {
         self.adts.get(name)
     }
 }
@@ -79,7 +79,7 @@ impl<A: Clone> Environment<A> {
         }
     }
 
-    pub fn map_adt(&mut self, name: Name, cons: Vec<ValueConstructor>) -> () {
+    pub fn map_adt(&mut self, name: Name, cons: HashMap<Name, Vec<Type>>) -> () {
         match self.stack.front_mut() {
             None => self.globals.map_adt(name, cons),
             Some(top) => top.map_adt(name, cons),
@@ -104,7 +104,7 @@ impl<A: Clone> Environment<A> {
         self.globals.lookup_function(name)
     }
 
-    pub fn lookup_adt(&self, name: &Name) -> Option<&Arc<Vec<ValueConstructor>>> {
+    pub fn lookup_adt(&self, name: &Name) -> Option<&Arc<HashMap<Name, Vec<Type>>>> {
         for scope in self.stack.iter() {
             if let Some(cons) = scope.lookup_adt(name) {
                 return Some(cons);

--- a/src/interpreter/expression_eval.rs
+++ b/src/interpreter/expression_eval.rs
@@ -454,7 +454,7 @@ fn eval_propagate_expression(
         Expression::COk(e) => Ok(ExpressionResult::Value(*e)),
         Expression::CErr(e) => Ok(ExpressionResult::Propagate(*e)),
         Expression::CNothing => Ok(ExpressionResult::Propagate(Expression::CString(
-            "Couldn't unwrap Nothing".to_string(),
+            "Couldn't unwrap Anything".to_string(),
         ))),
         _ => Err(String::from("'propagate' expects a Just or Ok.")),
     }
@@ -534,6 +534,15 @@ fn eval_list_value(
     }
     Ok(ExpressionResult::Value(Expression::ListValue(values)))
 }
+
+/* 
+fn eval_match_expression(
+    expr: Expression,
+    arms: Vec<Expression>,
+    env: &Environment<Expression>
+) -> Result<ExpressionResult, String> {
+    
+}*/
 
 #[cfg(test)]
 mod tests {

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 // Type alias for variable and function names
 pub type Name = String;
 
@@ -53,21 +55,7 @@ pub enum Type {
     TMaybe(Box<Type>),
     TResult(Box<Type>, Box<Type>), // Ok, Error
     TAny,
-    TAlgebraicData(Name, Vec<ValueConstructor>),
-}
-
-// Represents a value constructor for an algebraic data type
-#[derive(Debug, PartialEq, Clone)]
-pub struct ValueConstructor {
-    pub name: Name,
-    pub types: Vec<Type>,
-}
-
-impl ValueConstructor {
-    // Creates a new value constructor
-    pub fn new(name: Name, types: Vec<Type>) -> Self {
-        ValueConstructor { name, types }
-    }
+    TAlgebraicData(Name, HashMap<Name, Vec<Type>>),
 }
 
 // Represents expressions in the AST
@@ -121,6 +109,9 @@ pub enum Expression {
 
     // Constructor
     Constructor(Name, Vec<Box<Expression>>),
+    
+    // Match expression
+    Match(Box<Expression>, Vec<((Name, Vec<Name>), Expression)>),
 }
 
 // Represents statements in the AST
@@ -144,5 +135,5 @@ pub enum Statement {
     AssertFails(String),
     FuncDef(Function),
     Return(Box<Expression>),
-    TypeDeclaration(Name, Vec<ValueConstructor>),
+    TypeDeclaration(Name, HashMap<Name, Vec<Type>>),
 }

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -8,6 +8,7 @@ pub const KEYWORDS: &[&str] = &[
     "val",
     "var",
     "return",
+    "match",
     "Ok",
     "Err",
     "Just",

--- a/src/parser/parser_common.rs
+++ b/src/parser/parser_common.rs
@@ -36,9 +36,11 @@ pub const ASSERT_KEYWORD: &str = "assert";
 pub const VAR_KEYWORD: &str = "var";
 pub const VAL_KEYWORD: &str = "val";
 pub const DEF_KEYWORD: &str = "def";
+pub const MATCH_KEYWORD: &str = "match";
 
 // Operator and symbol constants
 pub const FUNCTION_ARROW: &str = "->";
+pub const MATCH_ARM_ARROW: &str = "=>";
 pub const PIPE_SYMBOL: &str = "|";
 pub const COLON_SYMBOL: &str = ":";
 pub const COMMA_SYMBOL: &str = ",";
@@ -49,6 +51,8 @@ pub const LEFT_BRACKET: char = '[';
 pub const RIGHT_BRACKET: char = ']';
 pub const LEFT_PAREN: char = '(';
 pub const RIGHT_PAREN: char = ')';
+pub const LEFT_BRACE: char = '{';
+pub const RIGHT_BRACE: char = '}';
 
 // Other character constants
 pub const COMMA_CHAR: char = ',';

--- a/src/type_checker/statement_type_checker.rs
+++ b/src/type_checker/statement_type_checker.rs
@@ -1,6 +1,7 @@
 use crate::environment::environment::Environment;
-use crate::ir::ast::{Expression, Function, Name, Statement, Type, ValueConstructor};
+use crate::ir::ast::{Expression, Function, Name, Statement, Type};
 use crate::type_checker::expression_type_checker::check_expr;
+use std::collections::HashMap;
 
 type ErrorMessage = String;
 
@@ -177,7 +178,7 @@ fn check_func_def_stmt(
 
 fn check_adt_declarations_stmt(
     name: Name,
-    cons: Vec<ValueConstructor>,
+    cons: HashMap<Name, Vec<Type>>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,5 +1,6 @@
 use r_python::ir::ast::*;
 use r_python::parser::{parse, parse_expression, parse_statement};
+use std::collections::HashMap;
 
 // Basic Expression Tests
 mod expression_tests {
@@ -318,13 +319,10 @@ mod adt_tests {
         let input = "data Shape = Circle Int | Rectangle Int Int";
         let expected = Statement::TypeDeclaration(
             "Shape".to_string(),
-            vec![
-                ValueConstructor::new("Circle".to_string(), vec![Type::TInteger]),
-                ValueConstructor::new(
-                    "Rectangle".to_string(),
-                    vec![Type::TInteger, Type::TInteger],
-                ),
-            ],
+            HashMap::from([
+                ("Circle".to_string(), vec![Type::TInteger]),
+                ("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),
+            ]),
         );
 
         let (rest, result) = parse_statement(input).unwrap();


### PR DESCRIPTION
1. Transformei o vetor de constructors do HashMap de adts de `Scope` em um ponteiro Arc para evitar clonagem do vetor na função `check_adt_constructor`;
2. Fiz as funções de checagem de tipos de expressões receberem referências às expressões (ou vetores de expressões) evitando cópias desnecessárias;
3. Acho que corrigi um erro no type checker do for (agora o tipo da variávek do for não é mais Any, é inferida com base no tipo da lista);
4. Reescrevi a função `check_adt_constructor` deixando ela mais idiomática