### PR TITLE
Aprimoramento no loop for

### DIFF
--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -134,4 +134,5 @@ pub enum Statement {
     FuncDef(Function),
     Return(Box<Expression>),
     TypeDeclaration(Name, Vec<ValueConstructor>),
+    Tuple(Vec<Expression>)
 }

--- a/src/type_checker/statement_type_checker.rs
+++ b/src/type_checker/statement_type_checker.rs
@@ -141,6 +141,28 @@ fn check_while_stmt(
     Ok(new_env)
 }
 
+// Função auxiliar para determinar o tipo do elemento iterável
+fn get_iterable_element_type(expr_type: &Type) -> Result<Type, ErrorMessage> {
+    match expr_type {
+        Type::TList(base_type) => Ok((**base_type).clone()),
+        Type::TString => Ok(Type::TString), // Caracteres como strings
+        Type::TTuple(types) => {
+            if types.is_empty() {
+                return Err("[Type Error] Cannot iterate over empty tuple type".to_string());
+            }
+            
+            // Verificar se todos os tipos são iguais (tupla homogênea)
+            let first_type = &types[0];
+            if types.iter().all(|t| t == first_type) {
+                Ok(first_type.clone())
+            } else {
+                Err("[Type Error] Can only iterate over homogeneous tuples (all elements same type)".to_string())
+            }
+        }
+        _ => Err(format!("[Type Error] Type {:?} is not iterable", expr_type))
+    }
+}
+
 fn check_for_stmt(
     var: Name,
     expr: Box<Expression>,
@@ -148,33 +170,26 @@ fn check_for_stmt(
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
-    let _var_type = env.lookup(&var);
+    
+    // Avaliar o tipo da expressão iterável
     let expr_type = check_expr(*expr, &new_env)?;
-    match expr_type {
-        Type::TList(base_type) => {
-            if let Some((_, t)) = env.lookup(&var) {
-                if t == *base_type || *base_type == Type::TAny {
-                    new_env = check_stmt(*stmt, &new_env)?;
-                    return Ok(new_env);
-                } else {
-                    return Err(format!(
-                        "[TypeError] Type mismatch between {:?} and {:?}",
-                        t, base_type
-                    ));
-                }
-            } else {
-                new_env.map_variable(var.clone(), false, *base_type);
-                new_env = check_stmt(*stmt, &new_env)?;
-                return Ok(new_env);
-            }
-        }
-        _ => {
-            return Err(format!(
-                "[TypeError] Expecting a List type, but found a {:?}",
-                expr_type
-            ))
-        }
-    }
+    
+    // Determinar o tipo do elemento
+    let element_type = get_iterable_element_type(&expr_type)?;
+    
+    // Criar novo escopo para o loop
+    new_env.push();
+    
+    // Mapear a variável iteradora no novo escopo
+    new_env.map_variable(var.clone(), false, element_type);
+    
+    // Verificar o corpo do loop no novo escopo
+    new_env = check_stmt(*stmt, &new_env)?;
+    
+    // Remover o escopo do loop
+    new_env.pop();
+    
+    Ok(new_env)
 }
 
 fn check_func_def_stmt(

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -109,6 +109,45 @@ mod expression_tests {
         assert_eq!(rest, "");
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_tuple_literals() {
+        let cases = vec![
+            (
+                "(1, 2, 3)",
+                Expression::Tuple(vec![
+                    Expression::CInt(1),
+                    Expression::CInt(2),
+                    Expression::CInt(3),
+                ]),
+            ),
+            (
+                "(\"hello\", True)",
+                Expression::Tuple(vec![
+                    Expression::CString("hello".to_string()),
+                    Expression::CTrue,
+                ]),
+            ),
+            ("()", Expression::Tuple(vec![])), 
+            (
+                "(42,)", 
+                Expression::Tuple(vec![Expression::CInt(42)]),
+            ),
+            (
+                "((1, 2), (3, 4))", 
+                Expression::Tuple(vec![
+                    Expression::Tuple(vec![Expression::CInt(1), Expression::CInt(2)]),
+                    Expression::Tuple(vec![Expression::CInt(3), Expression::CInt(4)]),
+                ]),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let (rest, result) = parse_expression(input).unwrap();
+            assert_eq!(rest, "");
+            assert_eq!(result, expected);
+        }
+    }
 }
 
 // Statement Tests
@@ -202,6 +241,75 @@ mod statement_tests {
         let (rest, result) = parse_statement(input).unwrap();
         assert_eq!(rest, "");
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_for_over_tuple() {
+        let cases = vec![
+            (
+                "for x in (1, 2, 3): x = x + 1; end",
+                Statement::For(
+                    "x".to_string(),
+                    Box::new(Expression::Tuple(vec![
+                        Expression::CInt(1),
+                        Expression::CInt(2),
+                        Expression::CInt(3),
+                    ])),
+                    Box::new(Statement::Block(vec![Statement::Assignment(
+                        "x".to_string(),
+                        Box::new(Expression::Add(
+                            Box::new(Expression::Var("x".to_string())),
+                            Box::new(Expression::CInt(1)),
+                        )),
+                    )])),
+                ),
+            ),
+            (
+                "for item in (\"a\", \"b\"): val x = item; end",
+                Statement::For(
+                    "item".to_string(),
+                    Box::new(Expression::Tuple(vec![
+                        Expression::CString("a".to_string()),
+                        Expression::CString("b".to_string()),
+                    ])),
+                    Box::new(Statement::Block(vec![Statement::ValDeclaration(
+                        "x".to_string(),
+                        Box::new(Expression::Var("item".to_string())),
+                    )])),
+                ),
+            ),
+            (
+                "for x in (): val y = 1; end", 
+                Statement::For(
+                    "x".to_string(),
+                    Box::new(Expression::Tuple(vec![])),
+                    Box::new(Statement::Block(vec![Statement::ValDeclaration(
+                        "y".to_string(),
+                        Box::new(Expression::CInt(1)),
+                    )])),
+                ),
+            ),
+            (
+                "for t in ((1,2), (3,4)): val x = t; end", 
+                Statement::For(
+                    "t".to_string(),
+                    Box::new(Expression::Tuple(vec![
+                        Expression::Tuple(vec![Expression::CInt(1), Expression::CInt(2)]),
+                        Expression::Tuple(vec![Expression::CInt(3), Expression::CInt(4)]),
+                    ])),
+                    Box::new(Statement::Block(vec![Statement::ValDeclaration(
+                        "x".to_string(),
+                        Box::new(Expression::Var("t".to_string())),
+                    )])),
+                ),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let (rest, result) = parse_statement(input).unwrap();
+            assert_eq!(rest, "");
+            assert_eq!(result, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Responsáveis**:
# Inácio Leal e Pedro Cortez Maia
## Técnicas utilizadas: Pair programming, Extreme Programming e programação funcional.

#O objetivo principal das mudanças é adicionar suporte para strings e tuplas em loops for
#Em adição melhoramos o escopo variavel do loop

## O que foi alterado:
Estende a funcionalidade do loop `for` para iterar sobre strings e tuplas homogêneas, além do suporte existente para listas.

## Motivo
- **Expressividade limitada**: Apenas listas eram iteráveis, restringindo casos de uso comuns
- **Conflitos de escopo**: Variáveis iteradoras compartilhavam escopo com variáveis externas, causando potenciais conflitos de nomenclatura
- **Lacunas de type safety**: Faltava validação para homogeneidade de tuplas e consistência de tipos de iteradores

## Como

### Type Checker (`statement_type_checker.rs`)
- **Adicionada** função `get_iterable_element_type()` para centralizar validação de tipos iteráveis
- **Refatorada** `check_for_stmt()` para usar escopo adequado com `push()`/`pop()`
- **Melhorada** validação de tipos para strings e tuplas homogêneas

### Runtime (`statement_execute.rs`)
- **Estendido** case `Statement::For` para tratar `Expression::CString` e `Expression::Tuple`
- **Melhoradas** mensagens de erro para tipos não suportados
- **Mantido** comportamento consistente de escopo entre todos os tipos iteráveis

## Mudanças

### Iteráveis Suportados
- ✅ `TList<T>` - funcionalidade existente preservada
- ✅ `TString` - itera sobre caracteres como strings individuais
- ✅ `TTuple<T>` - apenas tuplas homogêneas, tuplas heterogêneas rejeitadas em tempo de compilação

### Escopo da Variável do loop for:
- Variáveis iteradoras agora têm escopo isolado dentro do loop
- Sem conflitos com variáveis externas de mesmo nome
- Variáveis retornam ao escopo original após conclusão do loop

## Testando
```rust
// Iteração sobre string
for ch in "hello" { ... }

// Iteração sobre tupla homogênea
for num in (1, 2, 3) { ... }

// Isolamento de escopo
let x = "externa";
for x in [1, 2, 3] {
    // x é Integer aqui
}
// x é "externa" novamente
```

## Breaking Changes
- **Nenhum**: Código existente com loop `for` continua funcionando inalterado
- **Tempo de compilação**: Tuplas heterogêneas como `(1, "hello", true)` agora são adequadamente rejeitadas com mensagens de erro claras

## Arquivos Modificados
- `src/type_checker/statement_type_checker.rs`
- `src/interpreter/statement_execute.rs`