### PR TITLE
feat(parser): Implementa parser para if-elif-else e corrige função 'keyword'

### DIFF
--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -120,8 +120,8 @@ pub enum Statement {
     Assignment(Name, Box<Expression>),
     IfThenElse(Box<Expression>, Box<Statement>, Option<Box<Statement>>),
     IfChain {
-        branches: Vec<(Box<Expr>, Box<Block>)>,
-        else_branch: Option<Box<Block>>,
+        branches: Vec<(Box<Expression>, Box<Statement>)>,
+        else_branch: Option<Box<Statement>>,
     },
     While(Box<Expression>, Box<Statement>),
     For(Name, Box<Expression>, Box<Statement>),

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -119,6 +119,10 @@ pub enum Statement {
     ValDeclaration(Name, Box<Expression>),
     Assignment(Name, Box<Expression>),
     IfThenElse(Box<Expression>, Box<Statement>, Option<Box<Statement>>),
+    IfChain {
+        branches: Vec<(Box<Expr>, Box<Block>)>,
+        else_branch: Option<Box<Block>>,
+    },
     While(Box<Expression>, Box<Statement>),
     For(Name, Box<Expression>, Box<Statement>),
     Block(Vec<Statement>),

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -2,6 +2,7 @@ pub const KEYWORDS: &[&str] = &[
     "if",
     "in",
     "else",
+    "elif",
     "def",
     "while",
     "for",

--- a/src/parser/parser_common.rs
+++ b/src/parser/parser_common.rs
@@ -1,7 +1,7 @@
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::{alpha1, multispace0},
+    character::complete::{alpha1, multispace0, alphanumeric1},
     combinator::{not, peek, recognize},
     multi::many0,
     sequence::{delimited, terminated},
@@ -28,6 +28,7 @@ pub const END_KEYWORD: &str = "end";
 
 // Statement keyword constants
 pub const IF_KEYWORD: &str = "if";
+pub const ELIF_KEYWORD: &str = "elif";
 pub const ELSE_KEYWORD: &str = "else";
 pub const WHILE_KEYWORD: &str = "while";
 pub const FOR_KEYWORD: &str = "for";
@@ -67,11 +68,15 @@ pub fn separator<'a>(sep: &'static str) -> impl FnMut(&'a str) -> IResult<&'a st
 }
 
 /// Parses a reserved keyword (e.g., "if") surrounded by optional spaces
-/// Fails if followed by an identifier character
+/// A implementação da função keyword foi alterada para que seja garantida que a keyword seja uma palavra completa e seja separada por um espaço
 pub fn keyword<'a>(kw: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
-    terminated(
-        delimited(multispace0, tag(kw), multispace0),
-        not(peek(identifier_start_or_continue)),
+    delimited(
+        multispace0, 
+        terminated(
+            tag(kw), 
+            peek(not(alphanumeric1)), 
+        ),
+        multispace0, 
     )
 }
 

--- a/src/parser/parser_stmt.rs
+++ b/src/parser/parser_stmt.rs
@@ -23,6 +23,7 @@ pub fn parse_statement(input: &str) -> IResult<&str, Statement> {
         parse_var_declaration_statement,
         parse_val_declaration_statement,
         parse_assignment_statement,
+        parse_if_chain_statement,
         parse_if_else_statement,
         parse_while_statement,
         parse_for_statement,


### PR DESCRIPTION
## **Responsáveis:**
* João Marcelo Costa de Santana
* Gustavo Alencar Valadares
* Guilherme Delmonte

## **Mudanças feitas**
Este PR introduz um parser mais robusto para estruturas condicionais na linguagem r-python, adicionando suporte completo para a cadeia `if-elif-else`, e corrige um bug encontrado na função `keyword` durante o desenvolvimento.

### **Principais Mudanças:**

1.  **Novo Parser `if-elif-else`:**
    * Adicionada a função `parse_if_chain_statement` que lida com `if`, múltiplos `elif`s e um `else` opcional.
    * A antiga função `parse_if_else_statement` foi mantida no código. No parser principal (`parse_statement`), a nova função é chamada antes da antiga para garantir que estruturas com `elif` sejam reconhecidas corretamente.
    * Código do novo Parser:
    ```rust
    pub fn parse_if_chain_statement(input: &str) -> IResult<&str, Statement> {
        
        let (input_after_if, _) = keyword(IF_KEYWORD)(input)?;
        let (input_after_expr, cond_if) = parse_expression(input_after_if)?;
        let (input_after_block, block_if) = parse_block(input_after_expr)?;
        
        let mut branches = vec![(Box::new(cond_if), Box::new(block_if))];
        let mut current_input = input_after_block;
    
        loop {
            let result = tuple((keyword(ELIF_KEYWORD), parse_expression, parse_block))(current_input);
            match result {
                Ok((next_input, (_, cond_elif, block_elif))) => {
                    branches.push((Box::new(cond_elif), Box::new(block_elif)));
                    current_input = next_input;
                }
                Err(_) => break,
            }
        }
        let (input, else_branch) = opt(preceded(keyword(ELSE_KEYWORD), parse_block))(current_input)?;
        Ok((
            input,
            Statement::IfChain {
                branches,
                else_branch: else_branch.map(Box::new),
            },
        ))
    }
      ```

2.  **Correção em `keyword`:**
    * A implementação anterior da função `keyword` falhava ao tentar analisar uma palavra-chave seguida por outro identificador (ex: `if True`), o que impediu a execução inicial dos testes.
    * A lógica foi corrigida para o padrão `peek(not(alphanumeric1))`, garantindo que a palavra-chave seja reconhecida corretamente sem conflito com o código que a sucede. Com isso, conseguimos executar os testes para o novo parser com sucesso.
    * Antiga implementação:
    ```rust
    /// Parses a reserved keyword (e.g., "if") surrounded by optional spaces
        /// Fails if followed by an identifier character
        pub fn keyword<'a>(kw: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
            terminated(
                delimited(multispace0, tag(kw), multispace0),
                not(peek(identifier_start_or_continue)),
            )
        }
    ```
    * Nova implementação:
    ```rust
    pub fn keyword<'a>(kw: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
            delimited(
                multispace0, 
                terminated(
                    tag(kw), 
                    peek(not(alphanumeric1)), 
                ),
                multispace0, 
            )
    }
    ```

### **Testes:**
Adicionado um novo conjunto de testes unitários para a função `parse_if_chain_statement`, cobrindo os cenários de `if`, `if-else`, `if-elif` e `if-elif-else`. Ao executá-los utilizando o comando `cargo test`, obtivemos sucesso.

### **Como Testar**:
Basta rodar `cargo test`. Todos os testes devem passar.

### **Arquivos alterados**
- src/ir/ast.rs
- src/parser/keywords.rs
- src/parser/parser_common.rs
- src/parser/parser_stmt.rs