### PR TITLE
Match statement type checker and parsers fully working + additional changes focused on enhancing performance

### DIFF
--- a/src/environment/environment.rs
+++ b/src/environment/environment.rs
@@ -1,6 +1,6 @@
 use crate::ir::ast::Function;
 use crate::ir::ast::Name;
-use crate::ir::ast::ValueConstructor;
+use crate::ir::ast::Type;
 use std::collections::HashMap;
 use std::collections::LinkedList;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use std::sync::Arc;
 pub struct Scope<A> {
     pub variables: HashMap<Name, (bool, A)>,
     pub functions: HashMap<Name, Function>,
-    pub adts: HashMap<Name, Arc<Vec<ValueConstructor>>>,
+    pub adts: HashMap<Name, Arc<HashMap<Name, Vec<Type>>>>,
 }
 
 impl<A: Clone> Scope<A> {
@@ -31,7 +31,7 @@ impl<A: Clone> Scope<A> {
         return ();
     }
 
-    fn map_adt(&mut self, name: Name, adt: Vec<ValueConstructor>) -> () {
+    fn map_adt(&mut self, name: Name, adt: HashMap<Name, Vec<Type>>) -> () {
         self.adts.insert(name.clone(), Arc::new(adt));
         return ();
     }
@@ -46,7 +46,7 @@ impl<A: Clone> Scope<A> {
         self.functions.get(name)
     }
 
-    fn lookup_adt(&self, name: &Name) -> Option<&Arc<Vec<ValueConstructor>>> {
+    fn lookup_adt(&self, name: &Name) -> Option<&Arc<HashMap<Name, Vec<Type>>>> {
         self.adts.get(name)
     }
 }
@@ -79,7 +79,7 @@ impl<A: Clone> Environment<A> {
         }
     }
 
-    pub fn map_adt(&mut self, name: Name, cons: Vec<ValueConstructor>) -> () {
+    pub fn map_adt(&mut self, name: Name, cons: HashMap<Name, Vec<Type>>) -> () {
         match self.stack.front_mut() {
             None => self.globals.map_adt(name, cons),
             Some(top) => top.map_adt(name, cons),
@@ -104,7 +104,7 @@ impl<A: Clone> Environment<A> {
         self.globals.lookup_function(name)
     }
 
-    pub fn lookup_adt(&self, name: &Name) -> Option<&Arc<Vec<ValueConstructor>>> {
+    pub fn lookup_adt(&self, name: &Name) -> Option<&Arc<HashMap<Name, Vec<Type>>>> {
         for scope in self.stack.iter() {
             if let Some(cons) = scope.lookup_adt(name) {
                 return Some(cons);

--- a/src/environment/environment.rs
+++ b/src/environment/environment.rs
@@ -87,7 +87,7 @@ impl<A: Clone> Environment<A> {
     }
 
     pub fn lookup(&self, var: &Name) -> Option<(bool, A)> {
-        for scope in self.stack.iter() {
+        for scope in &self.stack {
             if let Some(value) = scope.lookup_var(var) {
                 return Some(value);
             }
@@ -96,7 +96,7 @@ impl<A: Clone> Environment<A> {
     }
 
     pub fn lookup_function(&self, name: &Name) -> Option<&Function> {
-        for scope in self.stack.iter() {
+        for scope in &self.stack {
             if let Some(func) = scope.lookup_function(name) {
                 return Some(func);
             }
@@ -105,7 +105,7 @@ impl<A: Clone> Environment<A> {
     }
 
     pub fn lookup_adt(&self, name: &Name) -> Option<&Arc<HashMap<Name, Vec<Type>>>> {
-        for scope in self.stack.iter() {
+        for scope in &self.stack {
             if let Some(cons) = scope.lookup_adt(name) {
                 return Some(cons);
             }
@@ -129,7 +129,7 @@ impl<A: Clone> Environment<A> {
         let mut vars = Vec::new();
 
         // First get variables from local scopes (in reverse order to respect shadowing)
-        for scope in self.stack.iter() {
+        for scope in &self.stack {
             for (name, value) in &scope.variables {
                 if !vars.iter().any(|(n, _)| n == name) {
                     vars.push((name.clone(), value.clone()));

--- a/src/environment/environment.rs
+++ b/src/environment/environment.rs
@@ -3,12 +3,13 @@ use crate::ir::ast::Name;
 use crate::ir::ast::ValueConstructor;
 use std::collections::HashMap;
 use std::collections::LinkedList;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Scope<A> {
     pub variables: HashMap<Name, (bool, A)>,
     pub functions: HashMap<Name, Function>,
-    pub adts: HashMap<Name, Vec<ValueConstructor>>,
+    pub adts: HashMap<Name, Arc<Vec<ValueConstructor>>>,
 }
 
 impl<A: Clone> Scope<A> {
@@ -31,7 +32,7 @@ impl<A: Clone> Scope<A> {
     }
 
     fn map_adt(&mut self, name: Name, adt: Vec<ValueConstructor>) -> () {
-        self.adts.insert(name.clone(), adt);
+        self.adts.insert(name.clone(), Arc::new(adt));
         return ();
     }
 
@@ -45,7 +46,7 @@ impl<A: Clone> Scope<A> {
         self.functions.get(name)
     }
 
-    fn lookup_adt(&self, name: &Name) -> Option<&Vec<ValueConstructor>> {
+    fn lookup_adt(&self, name: &Name) -> Option<&Arc<Vec<ValueConstructor>>> {
         self.adts.get(name)
     }
 }
@@ -103,7 +104,7 @@ impl<A: Clone> Environment<A> {
         self.globals.lookup_function(name)
     }
 
-    pub fn lookup_adt(&self, name: &Name) -> Option<&Vec<ValueConstructor>> {
+    pub fn lookup_adt(&self, name: &Name) -> Option<&Arc<Vec<ValueConstructor>>> {
         for scope in self.stack.iter() {
             if let Some(cons) = scope.lookup_adt(name) {
                 return Some(cons);

--- a/src/interpreter/expression_eval.rs
+++ b/src/interpreter/expression_eval.rs
@@ -454,7 +454,7 @@ fn eval_propagate_expression(
         Expression::COk(e) => Ok(ExpressionResult::Value(*e)),
         Expression::CErr(e) => Ok(ExpressionResult::Propagate(*e)),
         Expression::CNothing => Ok(ExpressionResult::Propagate(Expression::CString(
-            "Couldn't unwrap Nothing".to_string(),
+            "Couldn't unwrap Anything".to_string(),
         ))),
         _ => Err(String::from("'propagate' expects a Just or Ok.")),
     }
@@ -534,6 +534,15 @@ fn eval_list_value(
     }
     Ok(ExpressionResult::Value(Expression::ListValue(values)))
 }
+
+/* 
+fn eval_match_expression(
+    expr: Expression,
+    arms: Vec<Expression>,
+    env: &Environment<Expression>
+) -> Result<ExpressionResult, String> {
+    
+}*/
 
 #[cfg(test)]
 mod tests {

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -136,4 +136,5 @@ pub enum Statement {
     FuncDef(Function),
     Return(Box<Expression>),
     TypeDeclaration(Name, HashMap<Name, Vec<Type>>),
+    Match(Box<Expression>, Vec<((Name, Vec<Name>), Statement)>),
 }

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 // Type alias for variable and function names
 pub type Name = String;
 
@@ -53,21 +55,7 @@ pub enum Type {
     TMaybe(Box<Type>),
     TResult(Box<Type>, Box<Type>), // Ok, Error
     TAny,
-    TAlgebraicData(Name, Vec<ValueConstructor>),
-}
-
-// Represents a value constructor for an algebraic data type
-#[derive(Debug, PartialEq, Clone)]
-pub struct ValueConstructor {
-    pub name: Name,
-    pub types: Vec<Type>,
-}
-
-impl ValueConstructor {
-    // Creates a new value constructor
-    pub fn new(name: Name, types: Vec<Type>) -> Self {
-        ValueConstructor { name, types }
-    }
+    TAlgebraicData(Name, HashMap<Name, Vec<Type>>),
 }
 
 // Represents expressions in the AST
@@ -121,6 +109,9 @@ pub enum Expression {
 
     // Constructor
     Constructor(Name, Vec<Box<Expression>>),
+    
+    // Match expression
+    Match(Box<Expression>, Vec<((Name, Vec<Name>), Expression)>),
 }
 
 // Represents statements in the AST
@@ -144,5 +135,5 @@ pub enum Statement {
     AssertFails(String),
     FuncDef(Function),
     Return(Box<Expression>),
-    TypeDeclaration(Name, Vec<ValueConstructor>),
+    TypeDeclaration(Name, HashMap<Name, Vec<Type>>),
 }

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -110,9 +110,6 @@ pub enum Expression {
 
     // Constructor
     Constructor(Name, Vec<Box<Expression>>),
-    
-    // Match expression
-    Match(Box<Expression>, Vec<((Name, Vec<Name>), Expression)>),
 }
 
 // Represents statements in the AST
@@ -137,5 +134,5 @@ pub enum Statement {
     FuncDef(Function),
     Return(Box<Expression>),
     TypeDeclaration(Name, HashMap<Name, Vec<Type>>),
-    Match(Box<Expression>, Vec<((Name, Vec<Name>), Statement)>),
+    Match(Box<Expression>, Vec<(Expression, Statement)>),
 }

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -54,6 +54,7 @@ pub enum Type {
     TTuple(Vec<Type>),
     TMaybe(Box<Type>),
     TResult(Box<Type>, Box<Type>), // Ok, Error
+    TUnion(Vec<Type>), // Union type for propagate
     TAny,
     TAlgebraicData(Name, HashMap<Name, Vec<Type>>),
 }

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -8,6 +8,7 @@ pub const KEYWORDS: &[&str] = &[
     "val",
     "var",
     "return",
+    "match",
     "Ok",
     "Err",
     "Just",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,6 +3,7 @@ pub mod parser_common;
 pub mod parser_expr;
 pub mod parser_stmt;
 pub mod parser_type;
+pub mod parse_pattern;
 use nom::{
     character::complete::{char, multispace0},
     combinator::{map, opt},
@@ -17,6 +18,7 @@ use crate::parser::parser_common::SEMICOLON_CHAR;
 pub use parser_expr::parse_expression;
 pub use parser_stmt::parse_statement;
 pub use parser_type::parse_type;
+pub use parse_pattern::parse_pattern_argument;
 
 pub fn parse(input: &str) -> IResult<&str, Vec<Statement>> {
     map(

--- a/src/parser/parse_pattern.rs
+++ b/src/parser/parse_pattern.rs
@@ -1,0 +1,15 @@
+use nom::{IResult, branch::alt, combinator::map};
+use crate::ir::ast::Expression;
+use crate::parser::parser_expr::parse_literal_expression;
+use crate::parser::parser_common::identifier;
+
+pub fn parse_literal_pattern(input: &str) -> IResult<&str, Expression> {
+    parse_literal_expression(input)
+}
+
+pub fn parse_pattern_argument(input: &str) -> IResult<&str, Expression> {
+    alt((
+        parse_literal_pattern, // para números, strings, booleanos, etc.
+        map(identifier, |name| Expression::Var(name.to_string())),
+    ))(input)
+} 

--- a/src/parser/parser_common.rs
+++ b/src/parser/parser_common.rs
@@ -36,9 +36,11 @@ pub const ASSERT_KEYWORD: &str = "assert";
 pub const VAR_KEYWORD: &str = "var";
 pub const VAL_KEYWORD: &str = "val";
 pub const DEF_KEYWORD: &str = "def";
+pub const MATCH_KEYWORD: &str = "match";
 
 // Operator and symbol constants
 pub const FUNCTION_ARROW: &str = "->";
+pub const MATCH_ARM_ARROW: &str = "=>";
 pub const PIPE_SYMBOL: &str = "|";
 pub const COLON_SYMBOL: &str = ":";
 pub const COMMA_SYMBOL: &str = ",";
@@ -49,6 +51,8 @@ pub const LEFT_BRACKET: char = '[';
 pub const RIGHT_BRACKET: char = ']';
 pub const LEFT_PAREN: char = '(';
 pub const RIGHT_PAREN: char = ')';
+pub const LEFT_BRACE: char = '{';
+pub const RIGHT_BRACE: char = '}';
 
 // Other character constants
 pub const COMMA_CHAR: char = ',';

--- a/src/parser/parser_common.rs
+++ b/src/parser/parser_common.rs
@@ -79,6 +79,12 @@ pub fn keyword<'a>(kw: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, 
     )
 }
 
+/// Parses a keyword that can be followed by expressions or identifiers
+/// This is more flexible than the standard keyword parser
+pub fn flexible_keyword<'a>(kw: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
+    delimited(multispace0, tag(kw), multispace0)
+}
+
 /// Parsers for identifiers.
 pub fn identifier(input: &str) -> IResult<&str, &str> {
     let (input, _) = multispace0(input)?;
@@ -109,6 +115,6 @@ fn identifier_continue(input: &str) -> IResult<&str, &str> {
 }
 
 /// A single identifier character: alphanumeric or underscore
-fn identifier_start_or_continue(input: &str) -> IResult<&str, &str> {
+pub fn identifier_start_or_continue(input: &str) -> IResult<&str, &str> {
     recognize(alt((alpha1, tag("_"), nom::character::complete::digit1)))(input)
 }

--- a/src/parser/parser_expr.rs
+++ b/src/parser/parser_expr.rs
@@ -243,67 +243,6 @@ fn operator<'a>(op: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a
     delimited(multispace0, tag(op), multispace0)
 }
 
-/*fn parse_match_expression(input: &str) -> IResult<&str, Expression> {
-    map(
-        tuple((
-            keyword(MATCH_KEYWORD),
-            delimited(
-                multispace0,
-                parse_expression,
-                multispace0,
-            ),
-            char(COLON_CHAR),
-            multispace1,
-            separated_list0(
-                delimited(
-                    multispace0,
-                    char(COMMA_CHAR),
-                    multispace1,
-                ),
-                parse_match_arm,
-            ),
-            delimited(
-                multispace1,
-                tag(END_KEYWORD),
-                multispace1,
-            ),
-            keyword(MATCH_KEYWORD),
-        )),
-        |(_, expr, _, _, arms, _, _)| Expression::Match(Box::new(expr), arms),
-    )(input)
-}
-
-fn parse_match_arm(input: &str) -> IResult<&str, ((Name, Vec<Name>), Expression)> {
-    map(
-        tuple((
-            preceded(multispace0, identifier),
-            opt(delimited(
-                    preceded(multispace0, char::<&str, Error<&str>>(LEFT_PAREN)),
-                    separated_list0(
-                        delimited(multispace0, char::<&str, Error<&str>>(COMMA_CHAR), multispace0),
-                        identifier,
-                    ),
-                    preceded(multispace0, char::<&str, Error<&str>>(RIGHT_PAREN)),
-                )
-            ),
-            preceded(
-                delimited(
-                    multispace0,
-                    tag(MATCH_ARM_ARROW),
-                    multispace0,
-                ),
-                delimited(
-                    char::<&str, Error<&str>>(LEFT_BRACE),
-                    delimited(multispace0, parse_block, multispace0),
-                    char::<&str, Error<&str>>(RIGHT_BRACE),
-                ),
-            ),
-        )),
-        |(constructor, parameters, expression)| ((constructor.to_string(), parameters.unwrap_or_default().into_iter().map(|p| p.to_string()).collect()), expression),
-    )(input)
-}
-*/
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parser/parser_expr.rs
+++ b/src/parser/parser_expr.rs
@@ -1,7 +1,7 @@
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_while},
-    character::complete::{char, digit1, multispace0, multispace1},
+    character::complete::{char, digit1, multispace0},
     combinator::{map, map_res, opt, value, verify},
     error::Error,
     multi::{fold_many0, separated_list0},
@@ -11,7 +11,7 @@ use nom::{
 
 use std::str::FromStr;
 
-use crate::{ir::ast::{Expression, Name}};
+use crate::{ir::ast::{Expression}};
 use crate::parser::parser_common::{
     identifier,
     is_string_char,

--- a/src/parser/parser_expr.rs
+++ b/src/parser/parser_expr.rs
@@ -23,12 +23,6 @@ use crate::parser::parser_common::{
     LEFT_PAREN,
     RIGHT_BRACKET,
     RIGHT_PAREN,
-    // MATCH_KEYWORD,
-    // END_KEYWORD,
-    // COLON_CHAR,
-    // MATCH_ARM_ARROW,
-    // LEFT_BRACE,
-    // RIGHT_BRACE,
 };
 
 pub fn parse_expression(input: &str) -> IResult<&str, Expression> {
@@ -130,6 +124,10 @@ fn parse_factor(input: &str) -> IResult<&str, Expression> {
             char::<&str, Error<&str>>(RIGHT_PAREN),
         ),
     ))(input)
+}
+
+pub fn parse_literal_expression(input: &str) -> IResult<&str, Expression> {
+    alt((parse_bool, parse_number, parse_string))(input)
 }
 
 fn parse_bool(input: &str) -> IResult<&str, Expression> {
@@ -403,4 +401,29 @@ mod tests {
             panic!("Expected ListValue expression");
         }
     }
+
+    #[test]
+    fn test_parse_literal_expression_bool() {
+        assert_eq!(parse_literal_expression("True"), Ok(("", Expression::CTrue)));
+        assert_eq!(parse_literal_expression("False"), Ok(("", Expression::CFalse)));
+    }
+
+    #[test]
+    fn test_parse_literal_expression_int() {
+        assert_eq!(parse_literal_expression("42"), Ok(("", Expression::CInt(42))));
+        assert_eq!(parse_literal_expression("-7"), Ok(("", Expression::CInt(-7))));
+    }
+
+    #[test]
+    fn test_parse_literal_expression_real() {
+        assert_eq!(parse_literal_expression("3.14"), Ok(("", Expression::CReal(3.14))));
+        assert_eq!(parse_literal_expression("-0.5"), Ok(("", Expression::CReal(-0.5))));
+    }
+
+    #[test]
+    fn test_parse_literal_expression_string() {
+        assert_eq!(parse_literal_expression("\"abc\""), Ok(("", Expression::CString("abc".to_string()))));
+        assert_eq!(parse_literal_expression("\"\""), Ok(("", Expression::CString("".to_string()))));
+    }
 }
+

--- a/src/type_checker/expression_type_checker.rs
+++ b/src/type_checker/expression_type_checker.rs
@@ -42,7 +42,7 @@ pub fn check_expr(exp: &Expression, env: &Environment<Type>) -> Result<Type, Err
 fn check_var_name(name: Name, env: &Environment<Type>) -> Result<Type, ErrorMessage> {
     match env.lookup(&name) {
         Some((_, t)) => Ok(t.clone()),
-        None => Err(format!("[Name Error] '{}' is not defined.", name)),
+        None => Err(format!("[Name Error] Variable '{}' is not defined in the current scope.", name)),
     }
 }
 
@@ -227,7 +227,7 @@ fn check_adt_constructor(
             // Check that we have the right number of arguments
             if args.len() != constructor.len() {
                 return Err(format!(
-                    "[Type Error] Constructor '{}' expects {} arguments, but got {}.",
+                    "[Type Error] Constructor '{}' expects {} arguments, but {} were provided.",
                     name,
                     constructor.len(),
                     args.len()
@@ -249,7 +249,7 @@ fn check_adt_constructor(
             Ok(Type::TAlgebraicData(adt_type_name, (*constructors).clone()))
         }
         None => Err(format!(
-            "[Type Error] Constructor '{}' is not defined in any ADT.",
+            "[Name Error] Constructor '{}' is not defined in any loaded Algebraic Data Type (ADT).",
             name
         )),
     }

--- a/src/type_checker/expression_type_checker.rs
+++ b/src/type_checker/expression_type_checker.rs
@@ -233,6 +233,7 @@ fn check_adt_constructor(
                     args.len()
                 ));
             }
+
             // Check each argument's type
             for (arg, expected_type) in args.into_iter().zip(constructor.into_iter()) {
                 let arg_type = check_expr(&*arg, env)?;
@@ -243,6 +244,7 @@ fn check_adt_constructor(
                     ));
                 }
             }
+
             // Return the algebraic type
             Ok(Type::TAlgebraicData(adt_type_name, (*constructors).clone()))
         }
@@ -264,9 +266,13 @@ mod tests {
     #[test]
     fn check_constant() {
         let env = Environment::new();
+
         let c10 = CInt(10);
 
-        assert_eq!(check_expr(&c10, &env), Ok(TInteger));
+        assert_eq!(
+            check_expr(&c10, &env), 
+            Ok(TInteger)
+        );
     }
 
     #[test]
@@ -277,7 +283,10 @@ mod tests {
         let c20 = CInt(20);
         let add = Add(Box::new(c10), Box::new(c20));
 
-        assert_eq!(check_expr(&add, &env), Ok(TInteger));
+        assert_eq!(
+            check_expr(&add, &env), 
+            Ok(TInteger)
+        );
     }
 
     #[test]
@@ -288,7 +297,10 @@ mod tests {
         let c20 = CReal(20.3);
         let add = Add(Box::new(c10), Box::new(c20));
 
-        assert_eq!(check_expr(&add, &env), Ok(TReal));
+        assert_eq!(
+            check_expr(&add, &env), 
+            Ok(TReal)
+        );
     }
 
     #[test]
@@ -299,7 +311,10 @@ mod tests {
         let c20 = CReal(20.3);
         let add = Add(Box::new(c10), Box::new(c20));
 
-        assert_eq!(check_expr(&add, &env), Ok(TReal));
+        assert_eq!(
+            check_expr(&add, &env), 
+            Ok(TReal)
+        );
     }
 
     #[test]
@@ -310,7 +325,10 @@ mod tests {
         let c20 = CInt(20);
         let add = Add(Box::new(c10), Box::new(c20));
 
-        assert_eq!(check_expr(&add, &env), Ok(TReal));
+        assert_eq!(
+            check_expr(&add, &env), 
+            Ok(TReal)
+        );
     }
 
     #[test]
@@ -371,6 +389,7 @@ mod tests {
     #[test]
     fn check_ok_result() {
         let env = Environment::new();
+
         let e1 = CReal(10.0);
         let e2 = COk(Box::new(e1));
 
@@ -383,6 +402,7 @@ mod tests {
     #[test]
     fn check_err_result() {
         let env = Environment::new();
+
         let e1 = CInt(1);
         let e2 = CErr(Box::new(e1));
 
@@ -395,25 +415,34 @@ mod tests {
     #[test]
     fn check_just_integer() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = CJust(Box::new(e1));
 
-        assert_eq!(check_expr(&e2, &env), Ok(TMaybe(Box::new(TInteger))))
+        assert_eq!(
+            check_expr(&e2, &env), 
+            Ok(TMaybe(Box::new(TInteger)))
+        );
     }
 
     #[test]
     fn check_is_error_result_positive() {
         let env = Environment::new();
+
         let e1 = CTrue;
         let e2 = COk(Box::new(e1));
         let e3 = IsError(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TBool));
+        assert_eq!(
+            check_expr(&e3, &env), 
+            Ok(TBool)
+        );
     }
 
     #[test]
     fn check_is_error_result_error() {
         let env = Environment::new();
+
         let e1 = CTrue;
         let e2 = IsError(Box::new(e1));
 
@@ -427,107 +456,138 @@ mod tests {
     fn check_nothing() {
         let env = Environment::new();
 
-        assert_eq!(check_expr(&CNothing, &env), Ok(TMaybe(Box::new(TAny))));
+        assert_eq!(
+            check_expr(&CNothing, &env), 
+            Ok(TMaybe(Box::new(TAny)))
+        );
     }
 
     #[test]
     fn check_is_nothing_on_maybe() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = CJust(Box::new(e1));
         let e3 = IsNothing(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TBool));
+        assert_eq!(
+            check_expr(&e3, &env),
+            Ok(TBool)
+        );
     }
 
     #[test]
     fn check_is_nothing_type_error() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = IsNothing(Box::new(e1));
 
         assert!(
             matches!(check_expr(&e2, &env), Err(_)),
-            "expecting a maybe type value."
+            "Expecting a maybe type value."
         );
     }
 
     #[test]
     fn check_unwrap_maybe() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = CJust(Box::new(e1));
         let e3 = Unwrap(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TInteger));
+        assert_eq!(
+            check_expr(&e3, &env), 
+            Ok(TInteger)
+        );
     }
 
     #[test]
     fn check_unwrap_maybe_type_error() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = Unwrap(Box::new(e1));
 
         assert!(
             matches!(check_expr(&e2, &env), Err(_)),
-            "expecting a maybe or result type value."
+            "Expecting a maybe or result type value."
         );
     }
 
     #[test]
     fn check_unwrap_result() {
         let env = Environment::new();
+
         let e1 = CTrue;
         let e2 = COk(Box::new(e1));
         let e3 = Unwrap(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TBool));
+        assert_eq!(
+            check_expr(&e3, &env), 
+            Ok(TBool)
+        );
     }
 
     #[test]
     fn check_propagate_maybe() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = CJust(Box::new(e1));
         let e3 = Propagate(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TInteger));
+        assert_eq!(
+            check_expr(&e3, &env), 
+            Ok(TInteger)
+        );
     }
 
     #[test]
     fn check_propagate_maybe_type_error() {
         let env = Environment::new();
+
         let e1 = CInt(5);
         let e2 = Propagate(Box::new(e1));
 
         assert!(
             matches!(check_expr(&e2, &env), Err(_)),
-            "expecting a maybe or result type value."
+            "Expecting a maybe or result type value."
         );
     }
 
     #[test]
     fn check_propagate_result() {
         let env = Environment::new();
+
         let e1 = CTrue;
         let e2 = COk(Box::new(e1));
         let e3 = Propagate(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TUnion(vec![TBool, TAny])));
+        assert_eq!(
+            check_expr(&e3, &env), 
+            Ok(TUnion(vec![TBool, TAny]))
+        );
     }
 
     #[test]
     fn check_propagate_result_with_specific_error_type() {
         let env = Environment::new();
+
         let e2 = CErr(Box::new(CString("error".to_string())));
         let e3 = Propagate(Box::new(e2));
 
-        assert_eq!(check_expr(&e3, &env), Ok(TUnion(vec![TAny, TString])));
+        assert_eq!(
+            check_expr(&e3, &env), 
+            Ok(TUnion(vec![TAny, TString]))
+        );
     }
 
     #[test]
     fn test_undefined_variable() {
         let env = Environment::new();
+
         let exp = Expression::Var("x".to_string());
 
         // Should fail - x is not defined
@@ -537,23 +597,31 @@ mod tests {
     #[test]
     fn test_defined_variable() {
         let mut env = Environment::new();
+
         env.map_variable("x".to_string(), true, Type::TInteger);
         let exp = Expression::Var("x".to_string());
 
         // Should succeed and return integer type
-        assert_eq!(check_expr(&exp, &env), Ok(Type::TInteger));
+        assert_eq!(
+            check_expr(&exp, &env), 
+            Ok(Type::TInteger)
+        );
     }
 
     #[test]
     fn test_adt_constructor_valid() {
         let mut env = Environment::new();
+
         let figure_type = HashMap::from([
             ("Circle".to_string(), vec![Type::TInteger]),
             ("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),
         ]);
         env.map_adt("Figure".to_string(), figure_type);
 
-        let circle = Constructor("Circle".to_string(), vec![Box::new(CInt(5))]);
+        let circle = Constructor(
+            "Circle".to_string(), 
+            vec![Box::new(CInt(5))]
+        );
         let result = check_expr(&circle, &env);
         assert!(result.is_ok());
     }
@@ -561,6 +629,7 @@ mod tests {
     #[test]
     fn test_adt_constructor_wrong_args() {
         let mut env = Environment::new();
+
         let figure_type = HashMap::from([
             ("Circle".to_string(), vec![Type::TInteger]),
             ("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),
@@ -578,13 +647,18 @@ mod tests {
     #[test]
     fn test_adt_constructor_wrong_count() {
         let mut env = Environment::new();
+
         let figure_type = HashMap::from([
             ("Circle".to_string(), vec![Type::TInteger]),
             ("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),
         ]);
         env.map_adt("Figure".to_string(), figure_type);
-
-        let rectangle = Constructor("Rectangle".to_string(), vec![Box::new(CInt(5))]); // Missing second argument
+        
+        // Missing second argument
+        let rectangle = Constructor(
+            "Rectangle".to_string(), 
+            vec![Box::new(CInt(5))]
+        );
         let result = check_expr(&rectangle, &env);
         assert!(result.is_err());
     }
@@ -592,7 +666,11 @@ mod tests {
     #[test]
     fn test_adt_constructor_undefined() {
         let env = Environment::new();
-        let circle = Constructor("Circle".to_string(), vec![Box::new(CInt(5))]);
+
+        let circle = Constructor(
+            "Circle".to_string(), 
+            vec![Box::new(CInt(5))]
+        );
         let result = check_expr(&circle, &env);
         assert!(result.is_err());
     }
@@ -600,6 +678,7 @@ mod tests {
     #[test]
     fn test_adt_constructor_with_mutable_vars() {
         let mut env = Environment::new();
+
         let figure_type = HashMap::from([
             ("Circle".to_string(), vec![Type::TInteger]),
             ("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),

--- a/src/type_checker/statement_type_checker.rs
+++ b/src/type_checker/statement_type_checker.rs
@@ -6,104 +6,87 @@ use std::collections::HashMap;
 type ErrorMessage = String;
 
 pub fn check_stmt(
-    stmt: Statement,
+    stmt: &Statement,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     match stmt {
         Statement::VarDeclaration(var, expr) => check_var_declaration_stmt(var, expr, env),
-        Statement::ValDeclaration(var, expr) => check_val_declaration_stmt(var, expr, env),
         Statement::Sequence(stmt1, stmt2) => check_squence_stmt(stmt1, stmt2, env),
         Statement::Assignment(name, exp) => check_assignment_stmt(name, exp, env),
-        Statement::IfThenElse(cond, stmt_then, stmt_else_opt) => {
-            check_if_then_else_stmt(cond, stmt_then, stmt_else_opt, env)
-        }
+        Statement::IfThenElse(cond, stmt_then, stmt_else_opt) => check_if_then_else_stmt(cond, stmt_then, stmt_else_opt.as_deref(), env),
         Statement::While(cond, stmt) => check_while_stmt(cond, stmt, env),
         Statement::For(var, expr, stmt) => check_for_stmt(var, expr, stmt, env),
         Statement::FuncDef(function) => check_func_def_stmt(function, env),
         Statement::TypeDeclaration(name, cons) => check_adt_declarations_stmt(name, cons, env),
         Statement::Return(exp) => check_return_stmt(exp, env),
+        Statement::Match(expr, arms) => check_match_statement(expr, arms, env),
         _ => Err("Not implemented yet".to_string()),
     }
 }
 
 fn check_squence_stmt(
-    stmt1: Box<Statement>,
-    stmt2: Box<Statement>,
+    stmt1: &Box<Statement>,
+    stmt2: &Box<Statement>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
-    let new_env = check_stmt(*stmt1, &env)?;
-    check_stmt(*stmt2, &new_env)
+    let new_env = check_stmt(stmt1, &env)?;
+    check_stmt(stmt2, &new_env)
 }
 
 fn check_assignment_stmt(
-    name: Name,
-    exp: Box<Expression>,
+    name: &Name,
+    exp: &Box<Expression>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
-    let exp_type = check_expr(&*exp, &new_env)?;
+    let expr_type = check_expr(&*exp, &new_env)?;
 
-    match new_env.lookup(&name) {
-        Some((mutable, var_type)) => {
-            if !mutable {
-                return Err(format!(
-                    "[Type Error] Cannot assign to immutable variable '{}'.",
-                    name
-                ));
+    match new_env.lookup(name) {
+        Some((false, _)) => Err(format!("[Type Error] Cannot assign to immutable variable '{}'.", name)),
+        Some((_, var_type)) => {
+            if var_type == expr_type || var_type == Type::TAny {
+                new_env.map_variable(name.clone(), true, expr_type);
+                Ok(new_env)
+            } else {
+                return Err(format!("[Type Error] Cannot assign value of type '{:?}' to variable '{}', of type '{:?}'.", expr_type, name, var_type));
             }
-            if var_type != exp_type && var_type != Type::TAny && exp_type != Type::TAny {
-                return Err(format!(
-                    "[Type Error] Cannot assign value of type '{:?}' to variable '{}' of type '{:?}'.",
-                    exp_type, name, var_type
-                ));
-            }
-            new_env.map_variable(name, mutable, exp_type);
-            Ok(new_env)
-        }
-        None => Err(format!("[Name Error] Variable '{}' is not defined.", name)),
+        },
+        None => Err(format!("[Name Error] Variable '{}' was not declared in this scope.", name))
     }
 }
 
 fn check_var_declaration_stmt(
-    var: Name,
-    expr: Box<Expression>,
+    name: &Name,
+    expr: &Box<Expression>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
-    let exp_type = check_expr(&*expr, &new_env)?;
-    new_env.map_variable(var, true, exp_type);
-    Ok(new_env)
-}
+    let var_type = new_env.lookup(name);
+    let expr_type = check_expr(&*expr, &new_env)?;
 
-fn check_val_declaration_stmt(
-    var: Name,
-    expr: Box<Expression>,
-    env: &Environment<Type>,
-) -> Result<Environment<Type>, ErrorMessage> {
-    let mut new_env = env.clone();
-    let exp_type = check_expr(&*expr, &new_env)?;
-    new_env.map_variable(var, false, exp_type);
-    Ok(new_env)
+    if var_type.is_none() {
+        new_env.map_variable(name.clone(), true, expr_type);
+        Ok(new_env)
+    } else {
+        Err(format!("[Type Error] redeclaration of variable '{}'", name))
+    }
 }
 
 fn check_if_then_else_stmt(
-    cond: Box<Expression>,
-    stmt_then: Box<Statement>,
-    stmt_else_opt: Option<Box<Statement>>,
+    cond: &Box<Expression>,
+    stmt_then: &Box<Statement>,
+    stmt_else_opt: Option<&Statement>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
-    let mut new_env = env.clone();
-    let cond_type = check_expr(&*cond, &new_env)?;
-
+    let cond_type = check_expr(&*cond, env)?;
     if cond_type != Type::TBool {
-        return Err(String::from("[Type Error] Condition must be a boolean."));
+        return Err(String::from("[Type Error] The condition of an 'if' statement must be a boolean."));
     }
 
-    let then_env = check_stmt(*stmt_then, &new_env)?;
-
+    let then_env = check_stmt(stmt_then, env)?;
     match stmt_else_opt {
         Some(stmt_else) => {
-            let else_env = check_stmt(*stmt_else, &new_env)?;
+            let else_env = check_stmt(stmt_else, env)?;
             merge_environments(&then_env, &else_env)
         }
         None => Ok(then_env),
@@ -111,49 +94,38 @@ fn check_if_then_else_stmt(
 }
 
 fn check_while_stmt(
-    cond: Box<Expression>,
-    stmt: Box<Statement>,
+    cond: &Box<Expression>,
+    stmt: &Box<Statement>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
-    let mut new_env = env.clone();
-    let cond_type = check_expr(&*cond, &new_env)?;
-
+    let cond_type = check_expr(&*cond, env)?;
     if cond_type != Type::TBool {
-        return Err(String::from("[Type Error] Condition must be a boolean."));
+        return Err(String::from("[Type Error] The condition of a 'while' statement must be a boolean."));
     }
-
-    check_stmt(*stmt, &new_env)
+    check_stmt(stmt, env)
 }
 
 fn check_for_stmt(
-    var: Name,
-    expr: Box<Expression>,
-    stmt: Box<Statement>,
+    var: &Name,
+    expr: &Box<Expression>,
+    stmt: &Box<Statement>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
     let expr_type = check_expr(&*expr, &new_env)?;
-
-    // For now, we'll assume the expression should be a list
-    // This could be made more flexible in the future
     if !matches!(expr_type, Type::TList(_)) {
-        return Err(String::from("[Type Error] For loop expression must be a list."));
+        return Err(format!("[Type Error] Expected a list, but found {:?}", expr_type));
     }
-
-    // Extract the element type from the list type
     let element_type = match expr_type {
         Type::TList(element_type) => *element_type,
-        _ => Type::TAny, // This should never happen due to the check above
+        _ => Type::TAny,
     };
-
-    // Add the loop variable to the environment with the correct element type
-    new_env.map_variable(var, true, element_type);
-
-    check_stmt(*stmt, &new_env)
+    new_env.map_variable(var.clone(), true, element_type);
+    check_stmt(stmt, &new_env)
 }
 
 fn check_func_def_stmt(
-    function: Function,
+    function: &Function,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
@@ -167,35 +139,32 @@ fn check_func_def_stmt(
         );
     }
 
-    if let Some(body) = function.body.clone() {
-        new_env = check_stmt(*body, &new_env)?;
+    if let Some(body) = &function.body {
+        new_env = check_stmt(body, &new_env)?;
     }
     new_env.pop();
-    new_env.map_function(function);
+    new_env.map_function(function.clone());
 
     Ok(new_env)
 }
 
 fn check_adt_declarations_stmt(
-    name: Name,
-    cons: HashMap<Name, Vec<Type>>,
+    name: &Name,
+    cons: &HashMap<Name, Vec<Type>>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
-    new_env.map_adt(name.clone(), cons);
+    new_env.map_adt(name.clone(), cons.clone());
     Ok(new_env)
 }
 
 fn check_return_stmt(
-    exp: Box<Expression>,
+    exp: &Box<Expression>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();
-
     assert!(new_env.scoped_function());
-
     let ret_type = check_expr(&*exp, &new_env)?;
-
     match new_env.lookup(&"return".to_string()) {
         Some(_) => Ok(new_env),
         None => {
@@ -248,6 +217,48 @@ fn merge_environments(
     Ok(merged)
 }
 
+fn check_match_statement(
+    expr: &Expression,
+    arms: &Vec<((Name, Vec<Name>), Statement)>,
+    env: &Environment<Type>,
+) -> Result<Environment<Type>, ErrorMessage> {
+    let mut new_env = env.clone();
+    if let Type::TAlgebraicData(adt_name, mut constructors) = check_expr(expr, &new_env)? {
+        arms.iter().try_for_each(|((name, args), arm_stmt)| {
+            match constructors.remove(name) {
+                None => Err(format!("[Type Error] Constructor '{}' is not defined in ADT '{}'.", name, adt_name)),
+                Some(types) => {
+                    new_env.push();
+                    if types.len() != args.len() {
+                        return Err(format!("[Type Error] Constructor '{}' expects {} arguments, but got {}.", name, types.len(), args.len()));
+                    }
+                    for (tp, arg) in types.into_iter().zip(args.iter()) {
+                        // Se a variável já existe no ambiente externo, preserve a mutabilidade original
+                        let mutability = env.lookup(arg).map(|(m, _)| m).unwrap_or(false);
+                        new_env.map_variable(arg.clone(), mutability, tp);
+                    }
+                    check_stmt(arm_stmt, &new_env)?;
+                    new_env.pop();
+                    Ok(())
+                }
+            }
+        })?;
+        if !constructors.is_empty() {
+            return Err(format!(
+                "[Type Error] The adt isn't exhausted. Missing the following constructor(s): {}",
+                constructors
+                    .into_iter()
+                    .map(|(name, _)| name)
+                    .collect::<Vec<Name>>()
+                    .join(", ")
+            ));
+        }
+        Ok(new_env)
+    } else {
+        Err(format!("[Type Error] Expression must be an algebraic data type for match statement."))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,7 +266,6 @@ mod tests {
     use crate::ir::ast::Expression::*;
     use crate::ir::ast::FormalArgument;
     use crate::ir::ast::Function;
-    use crate::ir::ast::Statement::*;
     use crate::ir::ast::Type;
 
     #[test]
@@ -263,13 +273,13 @@ mod tests {
         let env: Environment<Type> = Environment::new();
         // Declare variable 'a' first
         let env = check_stmt(
-            Statement::VarDeclaration("a".to_string(), Box::new(CTrue)),
+            &Statement::VarDeclaration("a".to_string(), Box::new(CTrue)),
             &env,
         )
         .unwrap();
-        let assignment = Assignment("a".to_string(), Box::new(CTrue));
+        let assignment = Statement::Assignment("a".to_string(), Box::new(CTrue));
 
-        match check_stmt(assignment, &env) {
+        match check_stmt(&assignment, &env) {
             Ok(_) => assert!(true),
             Err(s) => assert!(false, "{}", s),
         }
@@ -280,16 +290,16 @@ mod tests {
         let env: Environment<Type> = Environment::new();
         // Declare variable 'a' first
         let env = check_stmt(
-            Statement::VarDeclaration("a".to_string(), Box::new(CTrue)),
+            &Statement::VarDeclaration("a".to_string(), Box::new(CTrue)),
             &env,
         )
         .unwrap();
-        let assignment1 = Assignment("a".to_string(), Box::new(CTrue));
-        let assignment2 = Assignment("a".to_string(), Box::new(CInt(1)));
-        let program = Sequence(Box::new(assignment1), Box::new(assignment2));
+        let assignment1 = Statement::Assignment("a".to_string(), Box::new(CTrue));
+        let assignment2 = Statement::Assignment("a".to_string(), Box::new(CInt(1)));
+        let program = Statement::Sequence(Box::new(assignment1), Box::new(assignment2));
 
         assert!(
-            matches!(check_stmt(program, &env), Err(_)),
+            matches!(check_stmt(&program, &env), Err(_)),
             "[Type Error on '__main__()'] 'a' has mismatched types: expected 'TBool', found 'TInteger'."
         );
     }
@@ -298,14 +308,14 @@ mod tests {
     fn check_if_then_else_error() {
         let env: Environment<Type> = Environment::new();
 
-        let stmt = IfThenElse(
+        let stmt = Statement::IfThenElse(
             Box::new(CInt(1)),
-            Box::new(Assignment("a".to_string(), Box::new(CInt(1)))),
-            Some(Box::new(Assignment("b".to_string(), Box::new(CReal(2.0))))),
+            Box::new(Statement::Assignment("a".to_string(), Box::new(CInt(1)))),
+            Some(Box::new(Statement::Assignment("b".to_string(), Box::new(CReal(2.0))))),
         );
 
         assert!(
-            matches!(check_stmt(stmt, &env), Err(_)),
+            matches!(check_stmt(&stmt, &env), Err(_)),
             "[Type Error on '__main__()'] if expression must be boolean."
         );
     }
@@ -314,22 +324,22 @@ mod tests {
     fn check_while_error() {
         let env: Environment<Type> = Environment::new();
 
-        let assignment1 = Assignment("a".to_string(), Box::new(CInt(3)));
-        let assignment2 = Assignment("b".to_string(), Box::new(CInt(0)));
-        let stmt = While(
+        let assignment1 = Statement::Assignment("a".to_string(), Box::new(CInt(3)));
+        let assignment2 = Statement::Assignment("b".to_string(), Box::new(CInt(0)));
+        let stmt = Statement::While(
             Box::new(CInt(1)),
-            Box::new(Assignment(
+            Box::new(Statement::Assignment(
                 "b".to_string(),
                 Box::new(Add(Box::new(Var("b".to_string())), Box::new(CInt(1)))),
             )),
         );
-        let program = Sequence(
+        let program = Statement::Sequence(
             Box::new(assignment1),
-            Box::new(Sequence(Box::new(assignment2), Box::new(stmt))),
+            Box::new(Statement::Sequence(Box::new(assignment2), Box::new(stmt))),
         );
 
         assert!(
-            matches!(check_stmt(program, &env), Err(_)),
+            matches!(check_stmt(&program, &env), Err(_)),
             "[Type Error on '__main__()'] while expression must be boolean."
         );
     }
@@ -339,19 +349,19 @@ mod tests {
     fn check_func_def() {
         let env: Environment<Type> = Environment::new();
 
-        let func = FuncDef(Function {
+        let func = Statement::FuncDef(Function {
             name: "add".to_string(),
             kind: Type::TInteger,
             params: vec![
                 FormalArgument::new("a".to_string(), Type::TInteger),
                 FormalArgument::new("b".to_string(), Type::TInteger),
             ],
-            body: Some(Box::new(Return(Box::new(Add(
+            body: Some(Box::new(Statement::Return(Box::new(Add(
                 Box::new(Var("a".to_string())),
                 Box::new(Var("b".to_string())),
             ))))),
         });
-        match check_stmt(func, &env) {
+        match check_stmt(&func, &env) {
             Ok(_) => assert!(true),
             Err(s) => assert!(false, "{}", s),
         }
@@ -362,7 +372,7 @@ mod tests {
         let env = Environment::new();
         // Declare variable 'x' first
         let env = check_stmt(
-            Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
+            &Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
             &env,
         )
         .unwrap();
@@ -379,7 +389,7 @@ mod tests {
         );
 
         // Should succeed - x is consistently an integer in both branches
-        assert!(check_stmt(stmt, &env).is_ok());
+        assert!(check_stmt(&stmt, &env).is_ok());
     }
 
     #[test]
@@ -398,7 +408,7 @@ mod tests {
         );
 
         // Should fail - x has different types in different branches
-        assert!(check_stmt(stmt, &env).is_err());
+        assert!(check_stmt(&stmt, &env).is_err());
     }
 
     #[test]
@@ -406,7 +416,7 @@ mod tests {
         let env = Environment::new();
         // Declare variable 'x' first
         let env = check_stmt(
-            Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
+            &Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
             &env,
         )
         .unwrap();
@@ -427,7 +437,7 @@ mod tests {
 
         // Should succeed - x is conditionally defined in then branch
         // and later used consistently as an integer
-        assert!(check_stmt(stmt, &env).is_ok());
+        assert!(check_stmt(&stmt, &env).is_ok());
     }
 
     #[test]
@@ -435,14 +445,14 @@ mod tests {
         let env = Environment::new();
         // Declare variable 'x' first
         let env = check_stmt(
-            Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
+            &Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
             &env,
         )
         .unwrap();
         let stmt = Statement::Assignment("x".to_string(), Box::new(Expression::CInt(42)));
 
         // Should succeed and add x:integer to environment
-        let new_env = check_stmt(stmt, &env).unwrap();
+        let new_env = check_stmt(&stmt, &env).unwrap();
         assert_eq!(
             new_env.lookup(&"x".to_string()),
             Some((true, Type::TInteger))
@@ -457,7 +467,7 @@ mod tests {
         let stmt = Statement::Assignment("x".to_string(), Box::new(Expression::CInt(100)));
 
         // Should succeed - reassigning same type
-        assert!(check_stmt(stmt, &env).is_ok());
+        assert!(check_stmt(&stmt, &env).is_ok());
     }
 
     #[test]
@@ -471,7 +481,7 @@ mod tests {
         );
 
         // Should fail - trying to reassign different type
-        assert!(check_stmt(stmt, &env).is_err());
+        assert!(check_stmt(&stmt, &env).is_err());
     }
 
     #[test]
@@ -516,7 +526,7 @@ mod tests {
                 )),
             )),
         );
-        let result = check_stmt(stmt, &env);
+        let result = check_stmt(&stmt, &env);
         if let Err(e) = &result {
             println!("Error: {}", e);
         }
@@ -539,7 +549,7 @@ mod tests {
             )),
         );
         // Should fail - list contains mixed types (integers and strings)
-        assert!(check_stmt(stmt, &env).is_err());
+        assert!(check_stmt(&stmt, &env).is_err());
     }
 
     #[test]
@@ -547,7 +557,7 @@ mod tests {
         let env = Environment::new();
         // Declare variable 'x' first
         let env = check_stmt(
-            Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
+            &Statement::VarDeclaration("x".to_string(), Box::new(Expression::CInt(0))),
             &env,
         )
         .unwrap();
@@ -560,7 +570,7 @@ mod tests {
             )),
         );
         // Should succeed - empty list is valid, though no iterations will occur
-        assert!(check_stmt(stmt, &env).is_ok());
+        assert!(check_stmt(&stmt, &env).is_ok());
     }
 
     #[test]
@@ -578,7 +588,7 @@ mod tests {
             )),
         );
         // Should fail - trying to assign string to iterator variable when iterating over integers
-        assert!(check_stmt(stmt, &env).is_err());
+        assert!(check_stmt(&stmt, &env).is_err());
     }
 
     #[test]
@@ -586,7 +596,7 @@ mod tests {
         let env = Environment::new();
         // Declare variable 'sum' first
         let env = check_stmt(
-            Statement::VarDeclaration("sum".to_string(), Box::new(Expression::CInt(0))),
+            &Statement::VarDeclaration("sum".to_string(), Box::new(Expression::CInt(0))),
             &env,
         )
         .unwrap();
@@ -613,7 +623,7 @@ mod tests {
         );
 
         // Should succeed - nested loops with proper variable usage
-        assert!(check_stmt(stmt, &env).is_ok());
+        assert!(check_stmt(&stmt, &env).is_ok());
     }
 
     #[test]
@@ -635,6 +645,118 @@ mod tests {
 
         // Should not succeed - for loop creates new scope, x is temporarily an integer
         // TODO: Let discuss this case here next class.
-        assert!(check_stmt(stmt, &env).is_err());
+        assert!(check_stmt(&stmt, &env).is_err());
+    }
+
+    #[test]
+    fn test_match_statement_exhaustive() {
+        use crate::ir::ast::Type::*;
+        use crate::ir::ast::Statement;
+        use crate::ir::ast::Expression::*;
+        use std::collections::HashMap;
+        let mut env = Environment::new();
+        let adt = HashMap::from([
+            ("A".to_string(), vec![TInteger]),
+            ("B".to_string(), vec![TBool]),
+        ]);
+        env.map_adt("MyEnum".to_string(), adt);
+        env.map_variable("x".to_string(), true, TInteger);
+        env.map_variable("y".to_string(), true, TBool);
+        let expr = Constructor("A".to_string(), vec![Box::new(CInt(1))]);
+        let match_stmt = Statement::Match(
+            Box::new(expr),
+            vec![
+                (("A".to_string(), vec!["x".to_string()]), Statement::Assignment("x".to_string(), Box::new(CInt(2)))),
+                (("B".to_string(), vec!["y".to_string()]), Statement::Assignment("y".to_string(), Box::new(CTrue))),
+            ],
+        );
+        let result = check_stmt(&match_stmt, &env);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_match_statement_non_exhaustive() {
+        use crate::ir::ast::Type::*;
+        use crate::ir::ast::Statement;
+        use crate::ir::ast::Expression::*;
+        use std::collections::HashMap;
+        let mut env = Environment::new();
+        let adt = HashMap::from([
+            ("A".to_string(), vec![TInteger]),
+            ("B".to_string(), vec![TBool]),
+        ]);
+        env.map_adt("MyEnum".to_string(), adt);
+        env.map_variable("x".to_string(), true, TInteger);
+        let expr = Constructor("A".to_string(), vec![Box::new(CInt(1))]);
+        let match_stmt = Statement::Match(
+            Box::new(expr),
+            vec![
+                (("A".to_string(), vec!["x".to_string()]), Statement::Assignment("x".to_string(), Box::new(CInt(2)))),
+                // Falta o braço para "B"
+            ],
+        );
+        let result = check_stmt(&match_stmt, &env);
+        if let Err(e) = result {
+            println!("Erro retornado: {}", e);
+            assert!(e.contains("The adt isn't exhausted"));
+        } else {
+            panic!("Esperado erro, mas foi Ok");
+        }
+    }
+
+    #[test]
+    fn test_match_statement_wrong_constructor() {
+        use crate::ir::ast::Type::*;
+        use crate::ir::ast::Statement;
+        use crate::ir::ast::Expression::*;
+        use std::collections::HashMap;
+        let mut env = Environment::new();
+        let adt = HashMap::from([
+            ("A".to_string(), vec![TInteger]),
+        ]);
+        env.map_adt("MyEnum".to_string(), adt);
+        env.map_variable("x".to_string(), true, TInteger);
+        env.map_variable("y".to_string(), true, TBool);
+        let expr = Constructor("A".to_string(), vec![Box::new(CInt(1))]);
+        let match_stmt = Statement::Match(
+            Box::new(expr),
+            vec![
+                (("A".to_string(), vec!["x".to_string()]), Statement::Assignment("x".to_string(), Box::new(CInt(2)))),
+                (("B".to_string(), vec!["y".to_string()]), Statement::Assignment("y".to_string(), Box::new(CTrue))), // "B" não existe
+            ],
+        );
+        let result = check_stmt(&match_stmt, &env);
+        if let Err(e) = result {
+            println!("Erro retornado: {}", e);
+            assert!(e.contains("is not defined in ADT"));
+        } else {
+            panic!("Esperado erro, mas foi Ok");
+        }
+    }
+
+    #[test]
+    fn test_match_statement_wrong_arg_count() {
+        use crate::ir::ast::Type::*;
+        use crate::ir::ast::Statement;
+        use crate::ir::ast::Expression::*;
+        use std::collections::HashMap;
+        let mut env = Environment::new();
+        let adt = HashMap::from([
+            ("A".to_string(), vec![TInteger]),
+        ]);
+        env.map_adt("MyEnum".to_string(), adt);
+        let expr = Constructor("A".to_string(), vec![Box::new(CInt(1))]);
+        let match_stmt = Statement::Match(
+            Box::new(expr),
+            vec![
+                (("A".to_string(), vec!["x".to_string(), "y".to_string()]), Statement::Assignment("x".to_string(), Box::new(CInt(2)))), // Argumentos a mais
+            ],
+        );
+        let result = check_stmt(&match_stmt, &env);
+        if let Err(e) = result {
+            assert!(e.contains("expects 1 arguments"));
+        } else {
+            panic!("Esperado erro, mas foi Ok");
+        }
     }
 }

--- a/src/type_checker/statement_type_checker.rs
+++ b/src/type_checker/statement_type_checker.rs
@@ -42,13 +42,13 @@ fn check_assignment_stmt(
     let expr_type = check_expr(&*exp, &new_env)?;
 
     match new_env.lookup(name) {
-        Some((false, _)) => Err(format!("[Type Error] Cannot assign to immutable variable '{}'.", name)),
+        Some((false, _)) => Err(format!("[Type Error] Cannot assign to immutable variable '{}'. Variables declared with 'val' cannot be changed.", name)),
         Some((_, var_type)) => {
             if var_type == expr_type || var_type == Type::TAny {
                 new_env.map_variable(name.clone(), true, expr_type);
                 Ok(new_env)
             } else {
-                return Err(format!("[Type Error] Cannot assign value of type '{:?}' to variable '{}', of type '{:?}'.", expr_type, name, var_type));
+                return Err(format!("[Type Mismatch] Variable '{}' has type '{:?}', but is being assigned a value of type '{:?}'", name, var_type, expr_type));
             }
         },
         None => Err(format!("[Name Error] Variable '{}' was not declared in this scope.", name))
@@ -68,7 +68,7 @@ fn check_var_declaration_stmt(
         new_env.map_variable(name.clone(), true, expr_type);
         Ok(new_env)
     } else {
-        Err(format!("[Type Error] redeclaration of variable '{}'", name))
+        Err(format!("[Type Error] Variable '{}' has already been declared in this scope.", name))
     }
 }
 
@@ -81,7 +81,7 @@ fn check_if_then_else_stmt(
     let cond_type = check_expr(&*cond, env)?;
     
     if cond_type != Type::TBool {
-        return Err(String::from("[Type Error] The condition of an 'if' statement must be a boolean."));
+        return Err(String::from("[Type Error] The condition of an 'if' statement must be a Boolean expression."));
     }
 
     let then_env = check_stmt(stmt_then, env)?;
@@ -102,7 +102,7 @@ fn check_while_stmt(
     let cond_type = check_expr(&*cond, env)?;
 
     if cond_type != Type::TBool {
-        return Err(String::from("[Type Error] The condition of a 'while' statement must be a boolean."));
+        return Err(String::from("[Type Error] The condition of a 'while' statement must be a Boolean expression."));
     }
 
     check_stmt(stmt, env)
@@ -118,7 +118,7 @@ fn check_for_stmt(
 
     let expr_type = check_expr(&*expr, &new_env)?;
     if !matches!(expr_type, Type::TList(_)) {
-        return Err(format!("[Type Error] Expected a list, but found {:?}", expr_type));
+        return Err(format!("[Type Error] The 'for' loop can only iterate over a list. Expected a List type, but found {:?}", expr_type));
     }
 
     let element_type = match expr_type {

--- a/src/type_checker/statement_type_checker.rs
+++ b/src/type_checker/statement_type_checker.rs
@@ -1,6 +1,7 @@
 use crate::environment::environment::Environment;
-use crate::ir::ast::{Expression, Function, Name, Statement, Type, ValueConstructor};
+use crate::ir::ast::{Expression, Function, Name, Statement, Type};
 use crate::type_checker::expression_type_checker::check_expr;
+use std::collections::HashMap;
 
 type ErrorMessage = String;
 
@@ -177,7 +178,7 @@ fn check_func_def_stmt(
 
 fn check_adt_declarations_stmt(
     name: Name,
-    cons: Vec<ValueConstructor>,
+    cons: HashMap<Name, Vec<Type>>,
     env: &Environment<Type>,
 ) -> Result<Environment<Type>, ErrorMessage> {
     let mut new_env = env.clone();

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,5 +1,6 @@
 use r_python::ir::ast::*;
 use r_python::parser::{parse, parse_expression, parse_statement};
+use std::collections::HashMap;
 
 // Basic Expression Tests
 mod expression_tests {
@@ -318,13 +319,10 @@ mod adt_tests {
         let input = "data Shape = Circle Int | Rectangle Int Int";
         let expected = Statement::TypeDeclaration(
             "Shape".to_string(),
-            vec![
-                ValueConstructor::new("Circle".to_string(), vec![Type::TInteger]),
-                ValueConstructor::new(
-                    "Rectangle".to_string(),
-                    vec![Type::TInteger, Type::TInteger],
-                ),
-            ],
+            HashMap::from([
+                ("Circle".to_string(), vec![Type::TInteger]),
+                ("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),
+            ]),
         );
 
         let (rest, result) = parse_statement(input).unwrap();


### PR DESCRIPTION
# Alterações

## Performance Enhancing
- All `src\type_checker\` functions now receive references instead of moved values, avoiding expensive and unnecessary `clone()`
- Constructors in a Algebraic Data Type are represented through `HashMap`s, which allows search in `O(1)`
- The adt's constructors in the stack are now stored in an `Arc<>` pointer, a thread-safe reference-counting pointer that enables shared ownership of data on the heap. This enhances performance because `.clone()` in `Arc` variables is **not** a deep copy (it does't copy the values on the heap, instead, it increments the Arc reference counter), therefore, it's more efficient for non-static types. This may be exaggerated worry with performance and could be considered an alien in the project since it's only used in this case (if performance is vital, we could try to use this aproach in other cases, otherwise, we can just forget about all this)

## Match Statement
- The `match` type checker is done and tested
- The `match` parser is done and tested

## Others
- Many functions on the type checker were re-written in order to become more idiomatic/understandable (and/or more efficient)
- Erros messages were enhanced, providing more context